### PR TITLE
Add skill-creator-agent

### DIFF
--- a/agents/shreyas-lyzr__skill-creator-agent/README.md
+++ b/agents/shreyas-lyzr__skill-creator-agent/README.md
@@ -1,0 +1,24 @@
+# skill-creator-agent
+
+An AI agent that helps you create, test, improve, and optimize skills for Claude Code and other AI assistants. It guides you through the full skill development lifecycle — from drafting SKILL.md to running evaluations, benchmarking, and optimizing trigger descriptions.
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/shreyas-lyzr/skill-creator-agent
+```
+
+## Capabilities
+
+- Draft new skills from scratch based on your intent
+- Write SKILL.md with proper frontmatter, instructions, and bundled resources
+- Generate realistic test prompts and run evaluations
+- Launch an interactive eval viewer for qualitative human review
+- Run quantitative benchmarks with variance analysis
+- Perform blind A/B comparisons between skill versions
+- Optimize skill descriptions for better triggering accuracy
+- Package skills for distribution
+
+## Built with
+
+[gitagent](https://github.com/open-gitagent/gitagent)

--- a/agents/shreyas-lyzr__skill-creator-agent/metadata.json
+++ b/agents/shreyas-lyzr__skill-creator-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "skill-creator-agent",
+  "author": "shreyas-lyzr",
+  "description": "An AI agent that helps you create, test, improve, and optimize skills for Claude Code and other AI assistants",
+  "repository": "https://github.com/shreyas-lyzr/skill-creator-agent",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["skills", "eval", "benchmark", "claude-code", "testing", "developer-tools"],
+  "license": "MIT",
+  "model": "claude-opus-4-6",
+  "adapters": ["claude-code", "openai", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
## Summary
- Adds **skill-creator-agent** to the gitagent registry
- An AI agent that helps create, test, improve, and optimize skills for Claude Code and other AI assistants
- Repository: https://github.com/shreyas-lyzr/skill-creator-agent

## Agent Details
- **Category**: developer-tools
- **Model**: claude-opus-4-6
- **Adapters**: claude-code, openai, system-prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)