### PR TITLE
Add gstack-agent — 6 workflow skills based on Garry Tan's gstack

### DIFF
--- a/agents/shreyas-lyzr__gstack-agent/README.md
+++ b/agents/shreyas-lyzr__gstack-agent/README.md
@@ -1,0 +1,18 @@
+# gstack-agent
+
+Six opinionated workflow skills that turn your AI coding assistant into a team of specialists — CEO/founder for product thinking, eng manager for architecture, staff engineer for review, release engineer for shipping, QA engineer for browser testing, and engineering manager for retrospectives. Based on [Garry Tan's gstack](https://github.com/garrytan/gstack).
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/shreyas-lyzr/gstack-agent
+```
+
+## Skills
+
+- **/plan-ceo-review** — Founder/CEO mode: rethink the problem, find the 10-star product
+- **/plan-eng-review** — Eng manager mode: architecture, data flow, diagrams, edge cases
+- **/review** — Paranoid staff engineer: find bugs that pass CI but break in production
+- **/ship** — Release engineer: sync main, test, version bump, push, open PR
+- **/browse** — QA engineer: headless Chromium for visual QA and screenshots
+- **/retro** — Engineering manager: weekly retrospective with velocity metrics

--- a/agents/shreyas-lyzr__gstack-agent/metadata.json
+++ b/agents/shreyas-lyzr__gstack-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "gstack-agent",
+  "author": "shreyas-lyzr",
+  "description": "Six opinionated workflow skills — CEO/founder product thinking, eng manager architecture, staff engineer review, release engineer shipping, QA browser testing, and engineering retrospectives. Based on Garry Tan's gstack.",
+  "repository": "https://github.com/shreyas-lyzr/gstack-agent",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["gstack", "workflow", "code-review", "shipping", "retrospective", "browser-testing", "plan-review"],
+  "license": "MIT",
+  "model": "claude-opus-4-6",
+  "adapters": ["claude-code", "openai", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
## Summary
- Adds `gstack-agent` to the registry — six opinionated workflow skills based on [Garry Tan's gstack](https://github.com/garrytan/gstack)
- Skills: /plan-ceo-review, /plan-eng-review, /review, /ship, /browse, /retro
- Repo: https://github.com/shreyas-lyzr/gstack-agent
- Model: claude-opus-4-6
- Adapters: claude-code, openai, system-prompt
- Category: developer-tools