### PR TITLE
Add exa-lead-gen-agent — Exa-powered lead generation

### DIFF
--- a/agents/shreyas-lyzr__exa-lead-gen-agent/README.md
+++ b/agents/shreyas-lyzr__exa-lead-gen-agent/README.md
@@ -1,0 +1,25 @@
+# exa-lead-gen-agent
+
+Generate enriched lead lists using Exa deep search with ICP scoring, micro-vertical expansion, parallel batch subagents, and CSV output.
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/shreyas-lyzr/exa-lead-gen-agent
+```
+
+## Prerequisites
+
+Requires an [Exa API key](https://dashboard.exa.ai/api-keys). Add the MCP server first:
+
+```bash
+claude mcp add --transport http exa "https://mcp.exa.ai/mcp?tools=deep_search_exa&exaApiKey=YOUR_EXA_API_KEY"
+```
+
+## What It Can Do
+
+- ICP research and validation from a single company name
+- Micro-vertical query expansion for maximum coverage
+- Parallel batch subagents for fast lead generation
+- Structured enrichment with ICP fit scores (1-10)
+- Deduplication, normalization, and clean CSV output

--- a/agents/shreyas-lyzr__exa-lead-gen-agent/metadata.json
+++ b/agents/shreyas-lyzr__exa-lead-gen-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "exa-lead-gen-agent",
+  "author": "shreyas-lyzr",
+  "description": "Generate enriched lead lists using Exa deep search with ICP scoring, micro-vertical expansion, parallel batch subagents, and CSV output.",
+  "repository": "https://github.com/shreyas-lyzr/exa-lead-gen-agent",
+  "version": "1.0.0",
+  "category": "sales",
+  "tags": ["lead-generation", "exa", "sales", "icp", "prospecting", "csv", "enrichment"],
+  "license": "MIT",
+  "model": "claude-opus-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}

--- a/agents/shreyas-lyzr__exa-lead-gen-agent/metadata.json
+++ b/agents/shreyas-lyzr__exa-lead-gen-agent/metadata.json
@@ -4,7 +4,7 @@
   "description": "Generate enriched lead lists using Exa deep search with ICP scoring, micro-vertical expansion, parallel batch subagents, and CSV output.",
   "repository": "https://github.com/shreyas-lyzr/exa-lead-gen-agent",
   "version": "1.0.0",
-  "category": "sales",
+  "category": "productivity",
   "tags": ["lead-generation", "exa", "sales", "icp", "prospecting", "csv", "enrichment"],
   "license": "MIT",
   "model": "claude-opus-4-6",


### PR DESCRIPTION
## Summary
- Adds `exa-lead-gen-agent` to the registry
- Generates enriched lead lists using Exa deep search with ICP scoring, micro-vertical expansion, parallel batch subagents, and CSV output
- Repo: https://github.com/shreyas-lyzr/exa-lead-gen-agent
- Model: claude-opus-4-6
- Category: sales
- Adapters: claude-code, system-prompt
- Requires Exa MCP server with API key