### PR TITLE
Add dashclaw-agent — AI agent governance expert

### DIFF
--- a/agents/ucsandman__dashclaw-agent/README.md
+++ b/agents/ucsandman__dashclaw-agent/README.md
@@ -1,0 +1,35 @@
+# DashClaw Agent
+
+The definitive expert on [DashClaw](https://github.com/ucsandman/DashClaw) — the decision infrastructure and policy firewall for AI agents.
+
+## What it does
+
+Helps developers integrate, configure, troubleshoot, and build DashClaw. Covers both using DashClaw (SDK integration, policies, approvals, compliance) and contributing to the DashClaw codebase.
+
+**Meta twist:** This agent governs itself on DashClaw. An agent for the agent governance platform, governed by the platform it represents.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| **instrument-agent** | Add DashClaw SDK to any agent (4-step governance loop) |
+| **create-policies** | Create guard policies (risk thresholds, approval gates, guardrails) |
+| **setup-dashclaw** | Set up DashClaw instance, CLI tool, and Claude Code hooks |
+| **manage-approvals** | Human-in-the-loop approval workflows (dashboard, CLI, SSE) |
+| **troubleshoot** | Debug errors (401/403/429/503), signals, and misconfigurations |
+| **build-dashclaw** | Contribute to codebase (architecture, 12-step scaffold, tests, CI) |
+| **compliance-drift-evals** | Compliance exports, drift detection, evaluations, scoring, learning |
+| **register-on-dashclaw** | Register any agent as a governed entity on DashClaw |
+
+## Knowledge
+
+- Full API reference (7 core routes + extensions)
+- V2 SDK reference (5-method surface, Node.js + Python)
+- V1 Legacy SDK reference (187 methods, 31 categories)
+- System architecture (3-tier, tech stack, database schema)
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/ucsandman/dashclaw-agent
+```

--- a/agents/ucsandman__dashclaw-agent/metadata.json
+++ b/agents/ucsandman__dashclaw-agent/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "dashclaw-agent",
+  "author": "ucsandman",
+  "description": "The definitive DashClaw expert — helps developers integrate, configure, troubleshoot, and build the AI agent governance platform. Governs itself on DashClaw.",
+  "repository": "https://github.com/ucsandman/dashclaw-agent",
+  "path": "",
+  "version": "1.0.0",
+  "category": "governance",
+  "tags": ["dashclaw", "governance", "ai-agents", "security", "compliance", "policy-firewall", "sdk", "hitl"],
+  "license": "MIT",
+  "model": "claude-opus-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
## Summary

- Adds **dashclaw-agent** to the gitagent registry
- The definitive expert on [DashClaw](https://github.com/ucsandman/DashClaw), the decision infrastructure and policy firewall for AI agents
- 8 skills covering SDK integration, policy creation, HITL approvals, troubleshooting, codebase contribution, compliance/drift/evals, and meta self-registration
- 4 knowledge files including full V1 legacy SDK reference (187 methods) and V2 SDK reference
- Passes `gitagent validate` with 0 errors, 0 warnings

## Agent Repository

https://github.com/ucsandman/dashclaw-agent

## Meta

This agent governs itself on DashClaw — an agent for the agent governance platform, governed by the platform it represents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)