### PR TITLE
Add SupportPilot agent submission

### DIFF
--- a/agents/Satyam999999/supportpilot/README.md
+++ b/agents/Satyam999999/supportpilot/README.md
@@ -1,0 +1,25 @@
+# SupportPilot
+
+SupportPilot is a grounded support-resolution and escalation-triage agent built for the GitAgent challenge.
+
+## Repository
+
+https://github.com/Satyam999999/Supportpilot-Gitagent
+
+## What It Does
+
+- Answers customer support questions using a curated FAQ knowledge base
+- Returns confidence scores and citation-backed responses
+- Escalates risky or uncertain requests with structured handoff reason codes
+
+## Local Setup and Run
+
+See the main repository README for complete setup and run instructions.
+
+## Core Project Files
+
+- agent.yaml
+- SOUL.md
+- README.md
+- reports/audits/
+- reports/submission/

--- a/agents/Satyam999999/supportpilot/metadata.json
+++ b/agents/Satyam999999/supportpilot/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "supportpilot",
+  "author": "Satyam999999",
+  "description": "Grounded support-resolution and escalation-triage agent with citation-backed responses and confidence scoring.",
+  "repository": "https://github.com/Satyam999999/Supportpilot-Gitagent",
+  "path": ".",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["support", "retrieval", "triage"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
## Agent Submission


This PR adds SupportPilot to the GitAgent registry.

- Agent name: SupportPilot
- Author: Satyam Ghosh
- Repository: https://github.com/Satyam999999/Supportpilot-Gitagent
- Summary: grounded support-resolution and escalation triage with citations, confidence scoring, and structured escalation reasons.

## Submission Checklist
- [x] Folder created at agents/<github-username>__<agent-name>/
- [x] metadata.json follows the schema
- [x] README.md included with description and usage
- [x] Agent repository is public
- [x] Repository contains valid agent.yaml
- [x] Repository contains SOUL.md