### PR TITLE
Add framework-translator-agent agent

### DIFF
--- a/agents/shreyas-lyzr__framework-translator-agent/README.md
+++ b/agents/shreyas-lyzr__framework-translator-agent/README.md
@@ -1,0 +1,20 @@
+# framework-translator-agent
+
+Translates AI agent code between 8 major frameworks: LangGraph, CrewAI, OpenAI Agents SDK, AutoGen, Semantic Kernel, Haystack, Agno/Phidata, and Google ADK. Analyzes source agent structure, produces a canonical intermediate representation, generates idiomatic target framework code, and validates translation fidelity with web search for unknown APIs.
+
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/shreyas-lyzr/framework-translator-agent
+```
+
+## Skills
+
+- `analyze`
+- `translate`
+- `validate`
+
+## Built with
+
+[gitagent](https://github.com/open-gitagent/gitagent) — a git-native, framework-agnostic open standard for AI agents.

--- a/agents/shreyas-lyzr__framework-translator-agent/metadata.json
+++ b/agents/shreyas-lyzr__framework-translator-agent/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "framework-translator-agent",
+  "author": "shreyas-lyzr",
+  "description": "Translates AI agent code between 8 major frameworks: LangGraph, CrewAI, OpenAI Agents SDK, AutoGen, Semantic Kernel, Haystack, Agno/Phidata, and Google ADK. Analyzes source agent structure, produces a",
+  "repository": "https://github.com/shreyas-lyzr/framework-translator-agent",
+  "version": "2.0.0",
+  "category": "developer-tools",
+  "tags": [],
+  "license": "MIT",
+  "model": "claude-opus-4-6",
+  "adapters": [
+    "claude-code",
+    "openai",
+    "system-prompt"
+  ],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
## Agent Submission

- **Name**: framework-translator-agent
- **Author**: shreyas-lyzr
- **Repository**: https://github.com/shreyas-lyzr/framework-translator-agent
- **Category**: developer-tools
- **Description**: Translates AI agent code between 8 major frameworks: LangGraph, CrewAI, OpenAI Agents SDK, AutoGen, Semantic Kernel, Haystack, Agno/Phidata, and Google ADK. Analyzes source agent structure, produces a canonical intermediate representation, generates idiomatic target framework code, and validates translation fidelity with web search for unknown APIs.


### Checklist

- [x] `metadata.json` follows the schema
- [x] `README.md` included
- [x] Agent repository is public
- [x] Repository contains valid `agent.yaml`
- [x] Repository contains `SOUL.md`