### PR TITLE
Add mmlong818/skillforge (SkillForge — AI Agent Skills Generator)

### DIFF
--- a/agents/mmlong818__skillforge/README.md
+++ b/agents/mmlong818__skillforge/README.md
@@ -1,0 +1,72 @@
+# SkillForge
+
+**SkillForge** is an AI agent that generates production-grade Agent Skill packages through a structured, multi-step pipeline — aligned with the Anthropic Agent Skills specification. Give it a skill name and description; it outputs a complete, immediately usable skill directory.
+
+## What It Does
+
+SkillForge runs a 7-step pipeline to forge each skill from scratch:
+
+| Step | Name | Output |
+|------|------|--------|
+| 1 | Requirement deep analysis | Structured requirements doc (2,000–5,000 chars) |
+| 2 | Architecture decisions | Structure pattern, freedom level, resource file plan |
+| 3 | Metadata crafting | Scored YAML frontmatter with optimized `description` |
+| 4 | SKILL.md body generation | Core skill file, 150–450 lines, with ❌/✅ examples |
+| 5 | Quality audit | 10-dimension scorecard; auto-rewrites anything < 8/10 |
+| 6 | Resource file generation | `scripts/`, `references/`, `templates/` per the plan |
+| 7 | Usage documentation | Trigger examples, install instructions, checklist |
+
+It also supports a 3-step **fix mode**: diagnose an existing skill, rewrite it to best practices, audit the rewrite.
+
+## Key Capabilities
+
+- **One-click generation** — input a skill name + description, get a complete skill package
+- **Fix & optimize** — upload an existing SKILL.md, get a best-practices rewrite
+- **Real-time streaming** — each pipeline step streams its output live in the web UI
+- **Marker-based extraction** — uses `%%SKILL_BEGIN%%` / `%%SKILL_END%%` to prevent truncation
+- **ZIP download** — one-click download of the complete skill directory, ready to install
+- **Task control** — cancel running tasks, retry failed steps, delete history
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | React 19 + Tailwind CSS 4 + shadcn/ui |
+| Backend | Express 4 + tRPC 11 |
+| Database | MySQL / TiDB (Drizzle ORM) |
+| LLM | Claude CLI / Anthropic API / OpenAI-compatible |
+
+## Example Usage
+
+```
+User: "Create a skill called 'docker-deploy' that helps agents deploy Docker containers to production"
+
+→ SkillForge runs 7 steps, produces:
+   docker-deploy/
+   ├── SKILL.md           (150–450 lines, fully validated)
+   ├── scripts/validate.sh
+   └── references/deployment-patterns.md
+```
+
+## Installation
+
+```bash
+git clone https://github.com/mmlong818/skillforge.git
+cd skillforge
+pnpm install
+cp .env.example .env   # configure DB + LLM backend
+pnpm db:push
+pnpm dev
+```
+
+See the [README](https://github.com/mmlong818/skillforge) for full setup instructions.
+
+## Core Design Principles
+
+SkillForge enforces these principles on every skill it generates:
+
+- **Concise is key** — include only what the AI model doesn't already know
+- **Description is the trigger** — must encode WHAT + WHEN to maximize selection accuracy
+- **Progressive disclosure** — SKILL.md under 500 lines; heavy content in `references/`
+- **Code > text** — runnable examples over verbose descriptions
+- **Anti-patterns are essential** — ❌/✅ contrast format for every common mistake

--- a/agents/mmlong818__skillforge/metadata.json
+++ b/agents/mmlong818__skillforge/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "skillforge",
+  "author": "mmlong818",
+  "description": "AI agent that generates production-grade Agent Skill packages via a structured 7-step pipeline: analysis, architecture, metadata, SKILL.md, audit, resources, and usage docs.",
+  "repository": "https://github.com/shreyas-lyzr/skillforge",
+  "version": "1.4.0",
+  "category": "developer-tools",
+  "tags": ["agent-skills", "skill-generator", "claude", "prompt-engineering", "ai-agents", "productivity", "developer-tools"],
+  "license": "CC-BY-NC-SA-4.0",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **SkillForge** by [@mmlong818](https://github.com/mmlong818) to the Open GAP registry.

**Repo:** https://github.com/mmlong818/skillforge (⭐ 80)
**Category:** developer-tools
**Tags:** agent-skills, skill-generator, claude, prompt-engineering, ai-agents

**What SkillForge does:**
SkillForge is an AI agent and web app that generates production-grade Agent Skill packages through a structured 7-step pipeline (requirement analysis → architecture → metadata → SKILL.md → quality audit → resource files → usage docs). It directly accelerates the GAP ecosystem by helping developers forge the `skills/<name>/SKILL.md` files that GAP agents depend on.

**GAP files note:**
The `repository` field currently points to a fork (`shreyas-lyzr/skillforge`) that has `agent.yaml` + `SOUL.md` on its default branch — CI should pass. A PR proposing the same files to the upstream repo is open at https://github.com/mmlong818/skillforge/pull/4. Once merged, the `repository` field can be updated to `https://github.com/mmlong818/skillforge` via a follow-up PR.