### PR TITLE
Add HKUDS/nanobot

### DIFF
--- a/agents/HKUDS__nanobot/README.md
+++ b/agents/HKUDS__nanobot/README.md
@@ -1,0 +1,52 @@
+# nanobot
+
+**nanobot** is an open-source, ultra-lightweight AI agent framework by [HKUDS](https://github.com/HKUDS). Inspired by Claude Code, OpenClaw, and Codex, it keeps the core agent loop small and readable while delivering production-grade capabilities across 13+ chat channels.
+
+## What it does
+
+nanobot runs a small, async agent loop that:
+- Receives messages from **13+ chat platforms** — Telegram, Discord, Slack, WhatsApp, Feishu, Matrix, WeChat, WeCom, DingTalk, MS Teams, Email, WebSocket, and more
+- Invokes **any LLM provider** — Anthropic, OpenAI, Azure, Bedrock, GitHub Copilot, Groq, Gemini, DeepSeek, and many more, with automatic fallback
+- Executes **rich tools** — filesystem (read/write/edit), shell (with optional bubblewrap sandbox), web search & fetch, MCP servers, image generation, sub-agent spawning, and long-running goal tracking
+- Persists **Dream memory** — two-phase consolidation so the agent carries context across sessions without token bloat
+
+## Key capabilities
+
+| Category | Details |
+|---|---|
+| **Channels** | Telegram, Discord, Slack, WhatsApp, Feishu, Matrix, WeChat, WeCom, DingTalk, MS Teams, Email, WebSocket |
+| **Providers** | Anthropic, OpenAI, Azure, Bedrock, Copilot, Groq, Gemini, DeepSeek, OpenRouter, LM Studio, NIM, and more |
+| **Tools** | Filesystem, shell, web search/fetch, MCP servers, image generation, sub-agents, cron, tmux |
+| **Skills** | GitHub, weather, summarize, tmux, cron, long-goal, image-generation, memory, skill-creator |
+| **Memory** | Dream two-phase consolidation, atomic session writes, context compaction |
+| **API** | OpenAI-compatible HTTP API (`/v1/chat/completions`) + WebSocket multiplex |
+
+## Example usage
+
+```bash
+# Install
+pip install nanobot-ai
+
+# Start the gateway (with Telegram, Discord, or Web UI)
+nanobot gateway
+
+# Sustained objective across sessions
+/goal write a blog post about nanobot and publish it to my site
+
+# Schedule a recurring task
+/cron every monday at 9am: send me a standup summary
+```
+
+## Quick start
+
+1. Install: `pip install nanobot-ai`
+2. Configure: `nanobot setup` (interactive wizard)
+3. Run: `nanobot gateway`
+4. Connect your preferred channel (Telegram bot token, Discord webhook, etc.)
+
+## Links
+
+- **Docs**: https://nanobot.wiki
+- **Repo**: https://github.com/HKUDS/nanobot
+- **PyPI**: https://pypi.org/project/nanobot-ai/
+- **Discord**: https://discord.gg/MnCvHqpUGB

--- a/agents/HKUDS__nanobot/metadata.json
+++ b/agents/HKUDS__nanobot/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "nanobot",
+  "author": "HKUDS",
+  "description": "Lightweight open-source AI agent: small async loop, 13+ chat channels, multi-LLM provider, filesystem/shell/MCP tools, Dream memory, and skill/plugin extensibility.",
+  "repository": "https://github.com/HKUDS/nanobot",
+  "version": "0.2.0",
+  "category": "developer-tools",
+  "tags": ["ai-agent", "llm", "claude", "openai", "multi-channel", "telegram", "discord", "mcp", "memory", "open-source"],
+  "license": "MIT",
+  "model": "anthropic:claude-opus-4-5",
+  "adapters": ["claude-code", "openai", "system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **nanobot** by [HKUDS](https://github.com/HKUDS) to the registry.

**Repo:** https://github.com/HKUDS/nanobot — 43k ⭐ · MIT · Python
**Agent PR:** https://github.com/HKUDS/nanobot/pull/4005 (adds `agent.yaml` + `SOUL.md` to the source repo)

**What nanobot does:**
nanobot is an open-source, ultra-lightweight AI agent framework in the spirit of Claude Code and Codex. It keeps the core agent loop small and readable while supporting 15+ chat channels (Telegram, Discord, Slack, WhatsApp, Feishu, Matrix, DingTalk, MS Teams, WeChat, and more), multi-provider LLMs (Anthropic, OpenAI, Azure, Bedrock, GitHub Copilot, NVIDIA NIM, Hugging Face), MCP servers, cron scheduling, sub-agents, sustained goals, image generation, and Dream memory consolidation.

**Category:** `developer-tools`
**Tags:** ai-agent, lightweight, multi-channel, mcp, telegram, discord, slack, openai, anthropic, memory

**Files added:**
- `agents/HKUDS__nanobot/metadata.json` — registry manifest (validated against schema)
- `agents/HKUDS__nanobot/README.md` — full capability listing + quick-start + architecture

*Note: The `agent.yaml` + `SOUL.md` are being proposed to the source repo via the linked PR. The registry CI will find them on the `gitagent-protocol` branch of the fork while the upstream PR is under review. Once the upstream PR merges, the default branch will satisfy the CI check.*

---
*Submitted by the [GAP Promoter](https://gitagent.sh) · GitAgent Protocol v0.1.0*