### PR TITLE
Add smol-ai/developer — human-centric junior developer agent

### DIFF
--- a/agents/smol-ai__smol-developer/README.md
+++ b/agents/smol-ai__smol-developer/README.md
@@ -1,0 +1,45 @@
+# smol developer
+
+> *"Build the thing that builds the thing."*
+
+**smol developer** is a human-centric AI junior developer agent that synthesises
+entire codebases from a single natural-language product spec. Point it at what
+you want to build, and it plans the architecture, maps out every file, and
+generates fully-implemented, comment-annotated code — no stubs, no TODOs.
+
+## What it does
+
+1. **Plans** — given your prompt, it produces a GitHub-Markdown architecture plan
+   naming every file, exported variable, DOM element ID, and function signature.
+2. **Specifies** — uses structured function-calling to return the exact file list
+   before writing a single line of code.
+3. **Generates** — creates each file individually, in full, following the agreed
+   plan. Raw valid source code only — no markdown fences, no placeholders.
+
+## Key capabilities
+
+- Full-program synthesis from one prompt (e.g. "a Pong game in HTML/JS/CSS")
+- Pluggable model support — defaults to GPT-4o, works with GPT-3.5-turbo
+- Streaming output with per-chunk callbacks
+- Embeddable as a Python library (`smol_dev` package)
+- Human-in-the-loop by design — you run the code and steer via prompt edits
+
+## Example usage
+
+```bash
+pip install smol-developer
+python main.py "a HTML/JS/CSS Tic Tac Toe game with AI opponent"
+```
+
+Or as a library:
+
+```python
+from smol_dev.main import main
+main(prompt="a REST API in FastAPI with SQLite persistence")
+```
+
+## Links
+
+- **Repository**: https://github.com/smol-ai/developer
+- **Original launch**: https://twitter.com/swyx/status/1657578738345979905
+- **GitAgent Protocol manifest**: `agent.yaml` + `SOUL.md` in the repo root

--- a/agents/smol-ai__smol-developer/metadata.json
+++ b/agents/smol-ai__smol-developer/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "smol-developer",
+  "author": "smol-ai",
+  "description": "A human-centric junior developer agent that synthesises entire codebases from a single prompt — plans, specifies files, and generates fully-implemented code with no TODOs.",
+  "repository": "https://github.com/smol-ai/developer",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["codegen", "scaffolding", "developer-agent", "gpt-4", "openai", "code-generation"],
+  "license": "MIT",
+  "model": "openai:gpt-4o",
+  "adapters": ["openai", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **smol-developer** by [@smol-ai](https://github.com/smol-ai) to the Open GAP registry.

**What the agent does:** Given a natural-language product spec, smol developer plans the full codebase architecture, specifies every file to be generated, and writes complete, comment-annotated source code — no stubs, no TODOs. It's one of the earliest and most recognised AI code-generation agents on GitHub (12k ⭐).

**Category:** `developer-tools`
**Tags:** `codegen`, `scaffolding`, `developer-agent`, `gpt-4`, `openai`, `code-generation`
**License:** MIT
**Model:** `openai:gpt-4o`

**Note on GAP files:** A companion PR adding `agent.yaml` + `SOUL.md` to the target repo has been opened here: https://github.com/smol-ai/developer/pull/173. The registry entry points to the upstream repo; once the target PR is merged, CI will be able to validate the files directly on the default branch.

**Files added:**
- `agents/smol-ai__smol-developer/metadata.json`
- `agents/smol-ai__smol-developer/README.md`

Thanks! 🦀