### PR TITLE
Add iannuttall/claude-agents

### DIFF
--- a/agents/iannuttall__claude-agents/README.md
+++ b/agents/iannuttall__claude-agents/README.md
@@ -1,0 +1,36 @@
+# claude-agents
+
+A curated library of **seven Claude Code custom sub-agents** by [@iannuttall](https://github.com/iannuttall), covering the full software-development lifecycle. Drop any agent into `.claude/agents/` and Claude Code automatically selects the right specialist for each task.
+
+## Available agents
+
+| Agent | What it does |
+|---|---|
+| **code-refactorer** | Improves code structure, readability, and maintainability without changing behaviour |
+| **security-auditor** | Performs comprehensive security audits and produces prioritised remediation reports |
+| **prd-writer** | Creates detailed, structured Product Requirements Documents |
+| **project-task-planner** | Converts a PRD into a fully-phased development task list |
+| **frontend-designer** | Translates mockups and wireframes into component specs and design systems |
+| **content-writer** | Produces high-quality written content for a wide range of purposes |
+| **vibe-coding-coach** | Translates app ideas and aesthetic preferences into working software |
+
+## Installation
+
+```bash
+# Project-scoped
+mkdir -p .claude/agents
+cp agents/*.md .claude/agents/
+
+# Global (all projects)
+mkdir -p ~/.claude/agents
+cp agents/*.md ~/.claude/agents/
+```
+
+## Usage
+
+Once installed, Claude Code detects and delegates tasks to the appropriate agent automatically — no extra configuration needed.
+
+## Links
+
+- Repository: https://github.com/iannuttall/claude-agents
+- License: MIT

--- a/agents/iannuttall__claude-agents/metadata.json
+++ b/agents/iannuttall__claude-agents/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-agents",
+  "author": "iannuttall",
+  "description": "Seven Claude Code sub-agents covering the full dev lifecycle: code refactoring, security auditing, PRD writing, task planning, frontend design, content writing, and vibe coaching.",
+  "repository": "https://github.com/iannuttall/claude-agents",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["claude-code", "sub-agents", "code-refactoring", "security", "prd", "frontend", "productivity"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **claude-agents** by [@iannuttall](https://github.com/iannuttall) to the Open GAP registry.

**Repo:** https://github.com/iannuttall/claude-agents (⭐ 2 059 stars, MIT)

**What it is:** A curated library of 7 Claude Code custom sub-agents — `code-refactorer`, `content-writer`, `frontend-designer`, `prd-writer`, `project-task-planner`, `security-auditor`, and `vibe-coding-coach`. Drop them into `.claude/agents/` and Claude Code auto-delegates tasks to the right specialist.

**Category:** `developer-tools`
**Tags:** claude-code, subagents, refactoring, security, content, frontend, productivity, prd, planning, coaching
**Model:** claude-sonnet-4-5-20250929
**Adapters:** claude-code, system-prompt

**GAP files:** A companion PR ([iannuttall/claude-agents#19](https://github.com/iannuttall/claude-agents/pull/19)) adds `agent.yaml` + `SOUL.md` to the source repo. The registry CI will validate against those files once merged; in the meantime the PR branch carries them on `gitagent-protocol`.

---
*Submitted by [GAP Promoter](https://gitagent.sh).*