### PR TITLE
Add dujonwalker/project-nova

### DIFF
--- a/agents/dujonwalker__project-nova/README.md
+++ b/agents/dujonwalker__project-nova/README.md
@@ -1,0 +1,60 @@
+# Project NOVA — Networked Orchestration of Virtual Agents
+
+**Project NOVA** is a comprehensive, self-hosted multi-agent AI assistant ecosystem that
+routes every user request to the right specialist through an intelligent hub-and-spoke
+architecture powered by n8n, MCP servers, and an OpenWebUI chat frontend.
+
+## What it does
+
+A central **Router Agent** analyses each incoming message and dispatches it to one of
+25+ domain-specific sub-agents, each backed by a dedicated MCP server running in Docker:
+
+| Domain | Agents |
+|---|---|
+| Knowledge Management | TriliumNext, Blinko, BookStack, Memos, Outline, SiYuan, Karakeep, Paperless, OnlyOffice |
+| Development & Repos | CLI Server, Forgejo, Gitea, System Search |
+| Media & Creative | Ableton Copilot, OBS, REAPER, REAPER QA, YouTube Transcript |
+| AI & Automation | Flowise, Langfuse, Puppeteer, RAGFlow, Fetch |
+| Monitoring & Home | Home Assistant, Prometheus |
+
+## Key capabilities
+
+- **Intelligent routing** — the router reads conversation history, recognises service
+  names, and dispatches to the right expert without asking unnecessary questions.
+- **25+ MCP servers** — every sub-agent is backed by a containerised MCP server;
+  Dockerfiles and docker-compose files are included for easy self-hosting.
+- **n8n orchestration** — n8n workflow JSON files handle the plumbing between the
+  OpenWebUI frontend, the router, and the sub-agents.
+- **Privacy-first** — everything runs locally; no data leaves your infrastructure.
+- **Extensible** — add new agents using the included prompt and container templates.
+
+## Example queries
+
+```
+"Search my TriliumNext notes for the project kick-off meeting notes"
+→ routed to: triliumnext-agent
+
+"Is the living room light on?"
+→ routed to: home-assistant-agent
+
+"Get the transcript of https://youtube.com/watch?v=..."
+→ routed to: youtube-agent
+
+"Create a new track in my REAPER project"
+→ routed to: reaper-agent
+```
+
+## Architecture
+
+```
+OpenWebUI  →  n8n workflow  →  Router Agent  →  Sub-Agent (MCP)
+                                                      ↓
+                                               Tool call result
+                                                      ↓
+                                          Response returned to user
+```
+
+## Getting started
+
+See the [full README and reference guide](https://github.com/dujonwalker/project-nova)
+for Docker setup, n8n workflow import, and per-agent configuration.

--- a/agents/dujonwalker__project-nova/metadata.json
+++ b/agents/dujonwalker__project-nova/metadata.json
@@ -1,0 +1,26 @@
+{
+  "name": "project-nova",
+  "author": "dujonwalker",
+  "description": "Self-hosted multi-agent AI hub: routes requests to 25+ MCP-powered specialists across knowledge mgmt, dev tools, media production, home automation & monitoring.",
+  "repository": "https://github.com/dujonwalker/project-nova",
+  "path": "",
+  "version": "1.0.0",
+  "category": "productivity",
+  "tags": [
+    "multi-agent",
+    "mcp",
+    "n8n",
+    "home-automation",
+    "self-hosted",
+    "router-agent",
+    "knowledge-management",
+    "media-production",
+    "openwebui",
+    "orchestration"
+  ],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["system-prompt", "claude-code"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **Project NOVA** by [@dujonwalker](https://github.com/dujonwalker) to the registry.

**Repo:** https://github.com/dujonwalker/project-nova
**GAP manifest PR:** https://github.com/dujonwalker/project-nova/pull/2

### What is Project NOVA?

Project NOVA (Networked Orchestration of Virtual Agents) is a self-hosted, multi-agent AI ecosystem with a router agent that dispatches requests to 25+ MCP-powered specialists — covering knowledge management, Git repos, media production (Ableton, OBS, REAPER), home automation (Home Assistant), browser automation, RAG retrieval, and system monitoring. Orchestrated via n8n with an OpenWebUI chat frontend.

### Entry details
- **Category:** `productivity`
- **Tags:** `multi-agent`, `mcp`, `n8n`, `home-automation`, `self-hosted`, `router-agent`, `knowledge-management`, `media-production`, `openwebui`, `orchestration`
- **Adapters:** `system-prompt`, `claude-code`
- **License:** MIT
- **Stars:** 263+

> ⚠️ Note: `agent.yaml` + `SOUL.md` are being added to the target repo via [PR #2](https://github.com/dujonwalker/project-nova/pull/2). The registry CI check against the default branch will pass once that PR is merged by the maintainer.