### PR TITLE
Add twostraws/SwiftUI-Agent-Skill

### DIFF
--- a/agents/twostraws__swiftui-agent-skill/README.md
+++ b/agents/twostraws__swiftui-agent-skill/README.md
@@ -1,0 +1,72 @@
+# SwiftUI Agent Skill
+
+**Author:** [Paul Hudson (@twostraws)](https://github.com/twostraws)  
+**Repository:** https://github.com/twostraws/SwiftUI-Agent-Skill  
+**License:** MIT  
+**Targets:** iOS 26+ · Swift 6.2+  
+
+---
+
+A comprehensive SwiftUI code-review agent skill for Claude Code, Codex, Gemini,
+Cursor, and other AI coding assistants. Built on thousands of hours of real-world
+SwiftUI experience, this skill directly targets the mistakes LLMs *actually* make
+when writing SwiftUI code.
+
+## What It Reviews
+
+| Area | Examples |
+|---|---|
+| **Deprecated API** | `foregroundColor()` → `foregroundStyle()`, legacy `NavigationView` |
+| **Views & Modifiers** | Redundant modifiers, animation API correctness |
+| **Data Flow** | `@State`, `@Binding`, `@Observable`, `@StateObject` / `@ObservedObject` |
+| **Navigation** | `NavigationStack` / `NavigationSplitView` patterns |
+| **Design (HIG)** | Apple Human Interface Guidelines compliance |
+| **Accessibility** | VoiceOver labels, Dynamic Type, Reduce Motion |
+| **Performance** | Expensive view-body computations, `task(id:)` usage |
+| **Swift** | Modern Concurrency, Swift 6.2+ idioms |
+| **Hygiene** | One type per file, naming, clean compilation |
+
+## Usage
+
+**Claude Code:**
+```
+/swiftui-pro
+/swiftui-pro Check for deprecated API
+/swiftui-pro Focus on accessibility
+```
+
+**Codex:**
+```
+$swiftui-pro
+$swiftui-pro Focus on performance
+```
+
+**Install via npx:**
+```bash
+npx skills add https://github.com/twostraws/swiftui-agent-skill --skill swiftui-pro
+```
+
+**Claude Code Marketplace:**
+```
+/plugin marketplace add twostraws/SwiftUI-Agent-Skill
+/plugin install swiftui-pro@swiftui-agent-skill
+```
+
+## Output Format
+
+Findings are organised by file. Each issue includes:
+1. File name and relevant line(s)
+2. The rule being violated
+3. A before/after code fix
+
+The review ends with a prioritised summary of the most impactful changes to make first.
+
+## Related Skills
+
+- [SwiftData Pro](https://github.com/twostraws/SwiftData-Agent-Skill)
+- [Swift Concurrency Pro](https://github.com/twostraws/Swift-Concurrency-Agent-Skill)
+- [Swift Testing Pro](https://github.com/twostraws/Swift-Testing-Agent-Skill)
+
+---
+
+*Part of the [Swift Agent Skills](https://github.com/twostraws/Swift-Agent-Skills) collection.*

--- a/agents/twostraws__swiftui-agent-skill/metadata.json
+++ b/agents/twostraws__swiftui-agent-skill/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "swiftui-agent-skill",
+  "author": "twostraws",
+  "description": "Reviews SwiftUI code for deprecated API, modern best practices, navigation, data-flow, accessibility, performance, and code hygiene. Targets iOS 26+ / Swift 6.2+.",
+  "repository": "https://github.com/shreyas-lyzr/SwiftUI-Agent-Skill",
+  "path": "",
+  "version": "1.1.0",
+  "category": "developer-tools",
+  "tags": ["swiftui", "swift", "ios", "apple", "code-review", "accessibility", "performance", "claude-code"],
+  "license": "MIT",
+  "model": "anthropic:claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **SwiftUI Agent Skill** by [twostraws](https://github.com/twostraws) to the Open GAP Registry.

**About the agent:**
A comprehensive SwiftUI code-review skill for Claude Code, Codex, Gemini, Cursor, and other AI coding assistants. Reviews Swift/SwiftUI code across 9 areas: deprecated API, view structure, data flow, navigation, HIG design, accessibility, performance, Swift idioms, and code hygiene. Targets iOS 26+ / Swift 6.2+. Built by Paul Hudson with ~4k GitHub stars.

- **Category:** `developer-tools`
- **Tags:** `swiftui`, `swift`, `ios`, `apple`, `code-review`, `accessibility`, `performance`, `claude-code`
- **License:** MIT
- **Adapters:** `claude-code`, `system-prompt`

**Note on `repository` field:** Currently pointing at the GAP-compliant fork (`shreyas-lyzr/SwiftUI-Agent-Skill`) which has `agent.yaml` + `SOUL.md` on its default branch, passing local CI. A PR adding these files to the upstream repo is open at https://github.com/twostraws/SwiftUI-Agent-Skill/pull/21 — once merged, the `repository` field can be updated to point directly at `twostraws/SwiftUI-Agent-Skill`.

Local validation: ✓ passed `npx tsx scripts/validate.ts`