### PR TITLE
Add undeadlist/claude-code-agents

### DIFF
--- a/agents/undeadlist__claude-code-agents/README.md
+++ b/agents/undeadlist__claude-code-agents/README.md
@@ -1,0 +1,61 @@
+# claude-code-agents
+
+A complete E2E development workflow for solo developers building with Next.js +
+Claude Code. Gives a single engineer the full leverage of a QA team, code
+reviewer, DevOps engineer, and security analyst — all via Claude Code subagents
+with strict, non-overlapping scopes.
+
+Built by Paul @ [UndeadList](https://undeadlist.com).
+
+## What It Does
+
+Orchestrates **24 specialised subagents** across five categories:
+
+| Category | Agents | Run Mode |
+|----------|--------|----------|
+| **Audit** (11) | bug, code-quality, security, docs, infra, UI/UX, database, performance, dependencies, SEO, API | Parallel |
+| **Fix/Implement** (4) | fix-planner, code-fixer, test-runner, test-writer | Sequential |
+| **Browser QA** (4) | browser-qa-agent, fullstack-qa-orchestrator, console-monitor, visual-diff | Mixed |
+| **Deploy** (2) | deploy-checker, env-validator | Sequential |
+| **Utility & Supervision** (3) | pr-writer, seed-generator, architect-reviewer | On-demand |
+
+## Workflow Skills
+
+Six slash-command workflows are available when installed as a Claude Code plugin:
+
+| Skill | Purpose |
+|-------|---------|
+| `/full-audit` | Spawns all 11 auditors in parallel → fix-planner |
+| `/pre-commit` | Bug + code-quality + security gate |
+| `/pre-deploy` | Full pre-deployment validation |
+| `/new-feature` | Plan → implement → QA loop |
+| `/bug-fix` | test-writer → code-fixer → test-runner |
+| `/release-prep` | Full audit + fixes + deploy-checker + pr-writer |
+
+## Key Design Principles
+
+- **Single security authority** — only `security-auditor` writes security findings; no overlap
+- **Mandatory status blocks** — every agent response opens with a YAML status block (`COMPLETE | PARTIAL | SKIPPED | ERROR`) for pipeline visibility
+- **Human-in-the-loop on destructive ops** — destructive changes require explicit confirmation
+- **`.env` is untouchable** — environment secrets are never modified
+
+## Installation
+
+```bash
+# Install as a Claude Code plugin (recommended — works across all projects)
+cat .claude-plugin/plugin.json
+
+# Or copy into a specific project
+./setup-project.sh
+```
+
+## Target Stack
+
+Next.js / React / TypeScript · Prisma · npm/pnpm · Vercel
+
+Other stacks can adapt the agent prompt files in `agents/`.
+
+## Links
+
+- [GitHub Repository](https://github.com/undeadlist/claude-code-agents)
+- [GitAgent Protocol](https://gitagent.sh)

--- a/agents/undeadlist__claude-code-agents/metadata.json
+++ b/agents/undeadlist__claude-code-agents/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-code-agents",
+  "author": "undeadlist",
+  "description": "Complete E2E dev workflow for solo startups: 24 parallel Claude Code subagents (audit, fix, browser QA, deploy) + 6 workflow skills for Next.js/TypeScript projects.",
+  "repository": "https://github.com/undeadlist/claude-code-agents",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["claude-code", "subagents", "audit", "code-quality", "solo-dev", "nextjs", "typescript", "qa", "devops", "full-stack"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **claude-code-agents** by [undeadlist](https://github.com/undeadlist) to the registry.

**Repo:** https://github.com/undeadlist/claude-code-agents
**Category:** developer-tools
**Stars:** 140 ⭐

**What it is:** A complete E2E development workflow for solo developers building with Next.js + Claude Code. Provides 24 specialised subagents (11 parallel auditors, 4 fix/implement, 4 browser QA, 2 deploy, 3 utility/supervisor) plus 6 workflow skills as Claude Code plugin slash commands.

**GAP files status:** A PR adding `agent.yaml` + `SOUL.md` to the upstream repo is open at https://github.com/undeadlist/claude-code-agents/pull/6. The metadata points to the public repo; once the PR merges the registry CI's clone check will pass cleanly.

**Why it belongs here:** Purpose-built agent orchestration system, MIT-licensed, actively maintained, already listed in [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code). A natural fit for solo devs looking for a production-grade Claude Code agent setup.