### PR TITLE
Add HKUDS/nanobot

### DIFF
--- a/agents/HKUDS__nanobot/README.md
+++ b/agents/HKUDS__nanobot/README.md
@@ -1,0 +1,67 @@
+# nanobot
+
+**nanobot** is a lightweight, open-source AI agent framework designed to be your personal, always-on assistant. It keeps the agent loop small and readable while delivering practical multi-channel chat, persistent memory, and a rich tool ecosystem.
+
+## What It Does
+
+nanobot receives messages from **15+ chat platforms** — Telegram, Discord, Slack, WhatsApp, WeChat, WeCom, Feishu, DingTalk, Matrix, QQ, MS Teams, Email, WebSocket, and a built-in React/TypeScript WebUI — and acts on them using an async LLM loop.
+
+### Key Capabilities
+
+| Capability | Details |
+|---|---|
+| **Multi-channel chat** | Telegram, Discord, Slack, Feishu, WhatsApp, WeChat, Teams, DingTalk, Matrix, Email, WebSocket, WebUI |
+| **LLM providers** | Anthropic, OpenAI, OpenAI-compatible, Azure, AWS Bedrock, GitHub Copilot, Codex, NVIDIA NIM, Hugging Face, and more |
+| **Tools** | Filesystem (read/write/edit), shell execution (sandboxed), web search/fetch, MCP server integration, image generation, subagent spawning |
+| **Memory** | Dream two-phase consolidation: atomic session writes, long-term memory distillation, context compaction |
+| **Long-horizon goals** | `/goal` command holds a sustained objective across many turns with visible progress |
+| **Cron & scheduling** | Natural-language cron reminders, scheduled tasks, heartbeat monitoring |
+| **WebUI** | Vite/React SPA with WebSocket multiplex, image uploads, streaming responses, locale switcher |
+| **OpenAI-compatible API** | `/v1/chat/completions` and `/v1/models` for programmatic access |
+
+## Quick Start
+
+```bash
+pip install nanobot-ai
+nanobot setup        # interactive wizard: pick provider, set API key
+nanobot gateway      # start the agent
+```
+
+Then connect your favourite chat channel via `nanobot --help` and start chatting.
+
+## Architecture
+
+nanobot uses an async `MessageBus` that decouples channels from the agent core:
+
+```
+Channel (Telegram/Discord/…)
+        │
+        ▼
+   MessageBus (async queue)
+        │
+        ▼
+   AgentLoop  ──▶  AgentRunner ──▶  LLM Provider
+                        │
+                        ▼
+                    Tool Execution
+                  (fs / shell / web / MCP …)
+                        │
+                        ▼
+                   OutboundMessage ──▶ Channel
+```
+
+The core loop (`loop.py`, `runner.py`) is intentionally small. New capabilities live in channels, tools, or skills — never inline in the loop.
+
+## Example Use Cases
+
+- **Personal assistant** — runs 24/7 on a VPS, answers Telegram messages, schedules reminders, and searches the web on your behalf.
+- **Coding helper** — integrates with your dev environment via MCP, reads/writes files, runs tests in a shell sandbox.
+- **Research agent** — given a `/goal`, searches the web, summarises findings, and reports back across multiple turns.
+- **Team bot** — connects to Slack or MS Teams, handles slash commands, forwards alerts, and manages shared reminders.
+
+## Links
+
+- **Docs**: https://nanobot.wiki
+- **Repo**: https://github.com/HKUDS/nanobot
+- **PyPI**: https://pypi.org/project/nanobot-ai/
+- **Discord**: https://discord.gg/MnCvHqpUGB

--- a/agents/HKUDS__nanobot/metadata.json
+++ b/agents/HKUDS__nanobot/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "nanobot",
+  "author": "HKUDS",
+  "description": "Lightweight, open-source AI agent with multi-channel chat (Telegram, Discord, Slack, WhatsApp, Feishu, WeChat, Teams), MCP, shell, filesystem, web search, Dream memory, cron, image gen, and a WebUI.",
+  "repository": "https://github.com/HKUDS/nanobot",
+  "path": "",
+  "version": "0.2.0",
+  "category": "developer-tools",
+  "tags": ["agent-framework", "multi-channel", "mcp", "memory", "telegram", "discord", "slack", "personal-agent", "python", "open-source"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **nanobot** by [HKUDS](https://github.com/HKUDS) to the Open GAP registry.

**Repo:** https://github.com/HKUDS/nanobot (43 000+ ★, MIT)

**What it does:** Lightweight open-source AI agent framework — chat channels (Telegram, Discord, Slack, Feishu, WhatsApp, WeChat, email, and more), multi-provider LLM (Anthropic, OpenAI, Azure, Bedrock, Gemini, DeepSeek…), tools (filesystem, shell sandbox, web, MCP, cron, image generation, sub-agents), Dream two-phase memory, and an installable skill system. One pip install.

**Category:** productivity
**Tags:** ai-agent, multi-channel, mcp, memory, tools, open-source, self-hosted, multi-provider, telegram, discord

**PR adding GAP files to the repo:** https://github.com/HKUDS/nanobot/pull/4024

> ⚠️ **Note for CI:** The registry validator checks for `agent.yaml` + `SOUL.md` on the default branch. Those files are proposed in the linked PR above (currently under review). Once that PR is merged, CI will pass. The files are already present on the `computer-agent:gitagent-protocol` branch if you'd like to verify the content early.