### PR TITLE
Add doobidoo/mcp-memory-service

### DIFF
--- a/agents/doobidoo__mcp-memory-service/README.md
+++ b/agents/doobidoo__mcp-memory-service/README.md
@@ -1,0 +1,68 @@
+# mcp-memory-service
+
+**Persistent shared memory for AI agent pipelines.**
+
+`mcp-memory-service` is an open-source, self-hosted memory backend that gives
+every AI agent a reliable, semantic, shared memory that survives across runs,
+across frameworks, and across infrastructure — with zero cloud lock-in.
+
+## What It Does
+
+| Without mcp-memory-service | With mcp-memory-service |
+|---|---|
+| Each agent run starts from zero | Agents retrieve prior decisions in < 5 ms |
+| Memory is local to one graph/run | Memory is shared across all agents and runs |
+| You manage Redis + Pinecone + glue code | One self-hosted service, zero cloud cost |
+| No causal relationships between facts | Knowledge graph with typed edges |
+| Context window limits create amnesia | Autonomous consolidation compresses old memories |
+
+## Key Capabilities
+
+- **Framework-agnostic REST API** — 76 endpoints; works with LangGraph, CrewAI, AutoGen, and any HTTP client
+- **MCP transport** — native Claude Desktop and OpenCode integration via Model Context Protocol
+- **Remote MCP** — HTTPS-first; works in claude.ai browser without Claude Desktop
+- **Causal knowledge graph** — typed edges (`causes`, `fixes`, `contradicts`) let agents reason over relationships
+- **Semantic retrieval** — sub-5 ms vector search via local ONNX embeddings; memory never leaves your infra
+- **Autonomous memory consolidation** — compresses and deduplicates aging memories automatically
+- **Quality scoring** — every memory is scored for relevance, recency, and completeness
+- **Cross-agent sharing** — `X-Agent-ID` header scopes memories by agent identity
+- **OAuth 2.1 + team collaboration** — enterprise-ready auth built in
+- **Web dashboard** — semantic search, tag browser, document ingestion, and analytics
+
+## Quick Start
+
+```bash
+pip install mcp-memory-service
+MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
+# REST API running at http://localhost:8000
+```
+
+```python
+import httpx
+
+BASE_URL = "http://localhost:8000"
+
+# Store a memory
+httpx.post(f"{BASE_URL}/memory", json={
+    "content": "The user prefers concise answers with code examples.",
+    "tags": ["preference", "style"],
+    "metadata": {"agent_id": "my-agent"}
+})
+
+# Retrieve semantically
+results = httpx.post(f"{BASE_URL}/memory/retrieve", json={
+    "query": "user preferences",
+    "n_results": 5
+}).json()
+```
+
+## Frameworks Supported
+
+LangGraph · CrewAI · AutoGen · Claude Desktop · OpenCode · Cursor · any HTTP client
+
+## Links
+
+- **Repository:** https://github.com/doobidoo/mcp-memory-service
+- **Documentation:** https://doobidoo.github.io/mcp-memory-service/
+- **Dashboard walkthrough:** https://youtu.be/W34r8VFoSdQ
+- **PyPI:** https://pypi.org/project/mcp-memory-service/

--- a/agents/doobidoo__mcp-memory-service/metadata.json
+++ b/agents/doobidoo__mcp-memory-service/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "mcp-memory-service",
+  "author": "doobidoo",
+  "description": "Self-hosted persistent memory backend for AI agent pipelines — REST API, MCP, OAuth 2.1, knowledge graph, semantic search, autonomous consolidation.",
+  "repository": "https://github.com/doobidoo/mcp-memory-service",
+  "version": "10.66.1",
+  "category": "developer-tools",
+  "tags": ["memory", "mcp", "knowledge-graph", "langchain", "crewai", "autogen", "semantic-search", "self-hosted"],
+  "license": "Apache-2.0",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **mcp-memory-service** by @doobidoo to the Open GAP Registry.

**What this agent does:** Self-hosted persistent memory backend for AI agent pipelines — REST API, MCP transport, OAuth 2.1, causal knowledge graph, semantic search in < 5 ms via local ONNX embeddings, autonomous memory consolidation, and a web dashboard. Works with LangGraph, CrewAI, AutoGen, Claude Desktop, OpenCode, and any HTTP client. Zero cloud lock-in.

**Details:**
- Repository: https://github.com/doobidoo/mcp-memory-service
- Category: `developer-tools`
- Tags: `memory`, `mcp`, `knowledge-graph`, `langchain`, `crewai`, `autogen`, `semantic-search`, `self-hosted`
- License: Apache-2.0
- Stars: ~1,900

> ⚠️ **Note on CI:** The companion PR adding `agent.yaml` + `SOUL.md` to the target repo is open at https://github.com/doobidoo/mcp-memory-service/pull/1030. The registry CI check that clones the target repo will pass once that PR is merged. This PR is intentionally opened now so both proposals are visible together — it can be held as a draft or merged after the target-repo PR lands.

**What is the GitAgent Protocol?**
A small open standard for portable AI agents ([gitagent.sh](https://gitagent.sh)) — every agent gets an `agent.yaml` manifest and a `SOUL.md` persona file, making it runnable on any GAP-compatible runtime.