### PR TITLE
Add patoles/agent-flow

### DIFF
--- a/agents/patoles__agent-flow/README.md
+++ b/agents/patoles__agent-flow/README.md
@@ -1,0 +1,36 @@
+# Agent Flow
+
+**Real-time visualization of Claude Code and Codex agent orchestration.**
+
+Agent Flow makes the invisible visible: as Claude Code or Codex executes, it renders every tool call, sub-agent spawn, and coordination step as a live, interactive node graph in your browser or VS Code side panel.
+
+## Key Capabilities
+
+- **Live node graph** — watch agent execution unfold as an interactive canvas you can pan, zoom, and click to inspect individual tool calls
+- **Multi-runtime support** — auto-detects Claude Code (via HTTP hooks) and Codex (via JSONL rollout tailing) concurrently, shown side-by-side
+- **Multi-session tracking** — manage multiple concurrent agent sessions with tabs, each tagged by runtime
+- **Timeline & transcript panels** — review the full execution timeline, file attention heatmap, and message transcript for any session
+- **JSONL log replay** — point at any `.jsonl` event log to replay or tail historical agent activity
+- **Zero-config startup** — `npx agent-flow-app` in one terminal, run your agent in another; events stream in real time
+
+## Usage
+
+```bash
+# Quickest path — no install required
+npx agent-flow-app
+
+# Then start a Claude Code session in another terminal
+claude "build me a REST API"
+```
+
+Or install the VS Code extension and open **Agent Flow** from the Command Palette (`Cmd+Shift+P`).
+
+## Why It Exists
+
+Debugging AI agent behavior is hard when all you see is the final output. Agent Flow was built out of real pain — tracing what went wrong in a multi-agent game-creation platform — and open-sourced so every developer working with AI agents can benefit.
+
+## Links
+
+- GitHub: https://github.com/patoles/agent-flow
+- Demo: https://www.youtube.com/watch?v=Ud6eDrFN-TA
+- License: Apache-2.0

--- a/agents/patoles__agent-flow/metadata.json
+++ b/agents/patoles__agent-flow/metadata.json
@@ -1,0 +1,24 @@
+{
+  "name": "agent-flow",
+  "author": "patoles",
+  "description": "Real-time visualization of Claude Code and Codex agent orchestration \u2014 watch agents think, branch, and coordinate as an interactive node graph.",
+  "repository": "https://github.com/computer-agent/agent-flow",
+  "version": "0.8.1",
+  "category": "developer-tools",
+  "tags": [
+    "claude-code",
+    "codex",
+    "visualization",
+    "agent-orchestration",
+    "debugging",
+    "vscode-extension",
+    "developer-tools"
+  ],
+  "license": "Apache-2.0",
+  "model": "anthropic:claude-sonnet-4-6",
+  "adapters": [
+    "claude-code",
+    "system-prompt"
+  ],
+  "icon": false
+}


### PR DESCRIPTION
Adds **agent-flow** by [@patoles](https://github.com/patoles) to the Open GAP Registry.

- **Repo:** https://github.com/patoles/agent-flow (941 ⭐)
- **What it does:** Real-time visualization of Claude Code and Codex agent orchestration — renders live execution as an interactive node graph, with multi-session tracking, timeline panels, and JSONL replay.
- **Category:** developer-tools
- **Tags:** claude-code, codex, visualization, agent-orchestration, debugging, vscode-extension
- **License:** Apache-2.0

A PR proposing `agent.yaml` + `SOUL.md` has been opened on the upstream repo: https://github.com/patoles/agent-flow/pull/55. The registry metadata currently points to the fork (`computer-agent/agent-flow`) where both GAP files are present on `main` — once the upstream PR is merged, the `repository` field can be updated to point to `https://github.com/patoles/agent-flow` directly.

Local validation passed ✓