### PR TITLE
Add mastersof-ai/harness

### DIFF
--- a/agents/mastersof-ai__harness/README.md
+++ b/agents/mastersof-ai__harness/README.md
@@ -1,0 +1,61 @@
+# Harness
+
+An open-source agent runtime where **you control the entire system prompt** — no hidden framework instructions, no behaviour injection, no black box.
+
+## What it does
+
+Define an agent by writing a single `IDENTITY.md` file. Run it with `mastersof-ai`. The harness loads your markdown exactly as written, appends only transparent operational context (date/time, workspace path, available tools), and starts a conversation powered by the Claude Agent SDK.
+
+```
+IDENTITY.md  →  mastersof-ai  →  Agent with exactly the context you gave it
+```
+
+## Key capabilities
+
+| Feature | Details |
+|---|---|
+| **Full prompt control** | Your IDENTITY.md is the system prompt — verbatim. No injected behaviour. |
+| **Terminal TUI** | `mastersof-ai [--agent x]` — React/Ink UI for solo, local development |
+| **Web UI** | `mastersof-ai --serve` — Fastify + React SPA, multi-user, token auth |
+| **In-process MCP tools** | memory, workspace, web-search, shell, tasks, introspection, sub-agents, A2A |
+| **Production-ready** | Rate limiting, cost caps, per-user isolation, LGPD-compliant privacy, bubblewrap sandbox |
+| **Sub-agents & A2A** | Spawn parallel agents or call remote A2A-protocol agents from within an agent |
+
+## Quick start
+
+```bash
+npm install -g @mastersof-ai/harness
+
+# Uses your existing Claude Code subscription or an API key
+mastersof-ai
+```
+
+On first run, `~/.mastersof-ai/` is created with three starter agents (cofounder, assistant, analyst) and a default config.
+
+## Create your own agent
+
+```bash
+mastersof-ai create my-agent
+# Edit ~/.mastersof-ai/agents/my-agent/IDENTITY.md
+mastersof-ai --agent my-agent
+```
+
+## Example IDENTITY.md
+
+```markdown
+# Market Analyst
+
+You are a senior market analyst. Your job is to research markets,
+identify trends, and deliver clear, actionable analysis.
+
+## How to work
+
+- Use web search to gather current data before forming opinions.
+- Structure every analysis with: thesis, evidence, risks, and conclusion.
+- Save key findings to memory so they compound across sessions.
+- Be direct. Commit to positions after weighing evidence.
+```
+
+## License
+
+MIT — https://github.com/mastersof-ai/harness/blob/master/LICENSE

--- a/agents/mastersof-ai__harness/metadata.json
+++ b/agents/mastersof-ai__harness/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "harness",
+  "author": "mastersof-ai",
+  "description": "Open-source agent runtime where you own the full system prompt. Define agents in a single IDENTITY.md, run them in a terminal TUI or multi-user web UI. Powered by the Claude Agent SDK.",
+  "repository": "https://github.com/mastersof-ai/harness",
+  "path": "",
+  "version": "0.2.0",
+  "category": "developer-tools",
+  "tags": ["agent-runtime", "claude", "system-prompt", "typescript", "tui", "web-ui", "mcp", "open-source", "ai-agent", "claude-code"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **mastersof-ai-harness** by mastersof-ai to the Open GAP registry.

**What it is:** A transparent agent runtime built on the Claude Agent SDK. Agents are defined as plain Markdown (`IDENTITY.md`) with zero hidden framework instructions — the file IS the system prompt. Supports a terminal TUI, multi-user web UI (serve mode), A2A protocol, MCP tools, persistent memory, and optional bubblewrap sandboxing.

**Repository:** https://github.com/mastersof-ai/harness
**Category:** developer-tools
**Tags:** agent-runtime, claude, typescript, tui, web-ui, a2a-protocol, mcp, sandbox, multi-agent

**GAP files note:** `agent.yaml` + `SOUL.md` have been proposed upstream via https://github.com/mastersof-ai/harness/pull/1 and are already present on the fork branch used for this submission. Once the upstream PR is merged, the registry can be updated to point at the canonical repo URL.

Local validation: ✓ passed `scripts/validate.ts`.