### PR TITLE
Add qx-labs/agents-deep-research

### DIFF
--- a/agents/qx-labs__agents-deep-research/README.md
+++ b/agents/qx-labs__agents-deep-research/README.md
@@ -1,0 +1,50 @@
+# agents-deep-research
+
+A powerful **multi-agent deep research assistant** built on the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) by [QX Labs](https://www.qxlabs.com). Given any research query, it iteratively hunts down knowledge gaps, dispatches specialised sub-agents to fill them, and synthesises everything into a comprehensive, fully-cited Markdown report.
+
+## Key Capabilities
+
+- **Two research modes:**
+  - `IterativeResearcher` — fast, focused queries → reports up to ~1,000 words / 5 pages
+  - `DeepResearcher` — long-form structured reports (20+ pages) via parallel section research
+- **Multi-agent pipeline:** KnowledgeGapAgent → ToolSelectorAgent → (WebSearchAgent | WebsiteCrawlerAgent) → WriterAgent → ProofreaderAgent
+- **Provider-agnostic:** runs on OpenAI, Anthropic, Gemini, DeepSeek, Perplexity, OpenRouter, Azure OpenAI, Hugging Face, Ollama, and LM Studio
+- **Automated:** no clarifying questions — usable end-to-end in pipelines
+- **Always cited:** every claim in the final report carries a numbered URL reference
+
+## Example Usage
+
+```python
+import asyncio
+from deep_researcher import IterativeResearcher, DeepResearcher
+
+# Simple research
+researcher = IterativeResearcher(max_iterations=5, max_time_minutes=5)
+report = asyncio.run(researcher.run("Overview of quantum computing", output_length="5 pages"))
+
+# Deep structured report
+researcher = DeepResearcher(max_iterations=3, max_time_minutes=10)
+report = asyncio.run(researcher.run("Comprehensive analysis of Tesla's market position"))
+
+print(report)
+```
+
+```bash
+# CLI
+pip install deep-researcher
+deep-researcher --mode deep --query "Life and works of Plato" --max-iterations 3 --max-time 10 --verbose
+```
+
+## Installation
+
+```bash
+pip install deep-researcher
+```
+
+See the [repository](https://github.com/qx-labs/agents-deep-research) for full setup instructions including API key configuration and custom tool extension.
+
+## Sample Outputs
+
+- [Life and Works of Plato](https://github.com/qx-labs/agents-deep-research/blob/main/examples/sample_output/plato.md) — 7,980 words
+- [Text Book on Quantum Computing](https://github.com/qx-labs/agents-deep-research/blob/main/examples/sample_output/quantum_computing.md) — 5,253 words
+- [Deep-Dive on Tesla](https://github.com/qx-labs/agents-deep-research/blob/main/examples/sample_output/tesla.md) — 4,732 words

--- a/agents/qx-labs__agents-deep-research/metadata.json
+++ b/agents/qx-labs__agents-deep-research/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "agents-deep-research",
+  "author": "qx-labs",
+  "description": "Multi-agent iterative deep research assistant. Identifies knowledge gaps, selects tools, gathers findings in parallel, and writes comprehensive cited Markdown reports.",
+  "repository": "https://github.com/qx-labs/agents-deep-research",
+  "path": "",
+  "version": "1.0.0",
+  "category": "research",
+  "tags": ["research", "deep-research", "multi-agent", "openai-agents-sdk", "web-search", "report-generation", "llm"],
+  "license": "Apache-2.0",
+  "model": "gpt-4o",
+  "adapters": ["openai", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **agents-deep-research** by [@qx-labs](https://github.com/qx-labs) to the Open GAP Registry.

**Repo:** https://github.com/qx-labs/agents-deep-research
**Category:** research
**Tags:** research, deep-research, multi-agent, openai-agents-sdk, web-search, report-generation, llm

This is a 768-star Python library that implements iterative multi-agent deep research using the OpenAI Agents SDK. It orchestrates five specialised sub-agents (KnowledgeGap, ToolSelector, WebSearch, WebsiteCrawler, Writer/Proofreader) to identify research gaps, gather findings in parallel, and synthesise fully-cited Markdown reports. Provider-agnostic: runs on OpenAI, Anthropic, Gemini, DeepSeek, and more.

A GAP adoption PR (agent.yaml + SOUL.md) has been opened against the upstream repo at https://github.com/qx-labs/agents-deep-research/pull/30 — the registry entry and the adoption PR go hand-in-hand; once the upstream merges the files, the registry CI will pass cleanly.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.