### PR TITLE
Add aiagentskit/claude-agents-library

### DIFF
--- a/agents/aiagentskit__claude-agents-library/README.md
+++ b/agents/aiagentskit__claude-agents-library/README.md
@@ -1,60 +1,58 @@
 # Claude Agents Library
 
 **34 production-ready Claude agent configurations** organised across 7 professional
-categories, ready to copy-paste as system prompts or drop into Claude Code's
-`.claude/agents/` directory.
+categories — ready to drop into Claude Code's `.claude/agents/` directory or paste
+as a system prompt in any Claude-compatible runtime.
 
 ## What It Does
 
-The Claude Agents Library gives you a curated roster of specialist AI personas —
-each one a deeply-configured Markdown file that transforms Claude into a domain
-expert with consistent behaviour, defined responsibilities, and example prompts.
+The Claude Agents Library gives you a curated roster of specialist AI personas.
+Each agent is a deeply-configured Markdown file that transforms Claude into a
+domain expert with a defined purpose, core responsibilities, key skills,
+communication style, and example prompts.
 
-Instead of starting from a blank system prompt every time, you grab the agent
-that matches your task, paste it in, and get a senior specialist.
+Instead of writing system prompts from scratch, you grab the right agent,
+copy it in, and get consistent, expert-level output every time.
 
 ## Categories & Agents
 
-| Category | Agents |
-|---|---|
-| **Design** (5) | Brand Guardian, UX Researcher, Visual Designer, Motion Designer, Design System Architect |
-| **Engineering** (6) | AI Engineer, Backend Architect, DevOps Automator, Frontend Developer, Mobile App Builder, Rapid Prototyper |
-| **Marketing** (7) | App Store Optimizer, Content Strategist, Growth Hacker, SEO Specialist, Social Media Manager, Email Marketer, Campaign Analyst |
-| **Product** (3) | Feedback Synthesizer, Product Roadmapper, Competitive Analyst |
-| **Project Management** (3) | Sprint Planner, Retrospective Facilitator, Risk Manager |
-| **Studio Operations** (5) | Client Relations Manager, Resource Planner, Process Documenter, Billing Specialist, Onboarding Guide |
-| **Testing** (5) | API Tester, QA Strategist, Performance Tester, Accessibility Auditor, Security Scanner |
+| Category | Count | Agents |
+|---|---|---|
+| **Engineering** | 6 | AI Engineer, Backend Architect, DevOps Automator, Frontend Developer, Mobile App Builder, Rapid Prototyper |
+| **Marketing** | 7 | TikTok Strategist, Instagram Curator, X/Twitter Strategist, Reddit Community Builder, App Store Optimizer, Content Creator, Growth Hacker |
+| **Design** | 5 | Brand Guardian, UI Designer, UX Researcher, Visual Storyteller, Whimsy Injector |
+| **Product** | 3 | Trend Researcher, Feedback Synthesizer, Sprint Prioritizer |
+| **Project Management** | 3 | Experiment Tracker, Project Shipper, Studio Producer |
+| **Studio Operations** | 5 | Support Responder, Analytics Reporter, Infrastructure Maintainer, Legal Compliance Checker, Finance Tracker |
+| **Testing** | 5 | Tool Evaluator, API Tester, Workflow Optimizer, Performance Benchmarker, Test Results Analyzer |
 
 ## Key Features
 
-- **v1.2 — 34 agents** across 7 professional categories
-- **Copy-paste ready** — each agent ships with purpose, responsibilities, skills, communication style, and example prompts
-- **Claude Code compatible** — drop agents into `.claude/agents/` for auto-discovery
+- **v1.2 — 34 agents** across 7 professional domains
+- **Copy-paste ready** — each agent ships with purpose, responsibilities, skills, and example prompts
+- **Claude Code compatible** — drop agents into `.claude/agents/` for automatic discovery
 - **MCP integration patterns** — 7 ready-made workflows with code examples
 - **Model selection matrix** — 30+ task-specific recommendations with cost comparisons
-- **Cost optimisation** — up to 82% savings with guidance on Haiku vs. Sonnet vs. Opus
+- **Cost optimisation guide** — up to 82% API cost savings with Haiku/Sonnet/Opus routing
 
 ## Quick Start
 
 ```bash
-# Project-specific
+# Project-specific install
 mkdir -p .claude/agents
-cp agents/engineering/ai-engineer.md .claude/agents/
+cp -r engineering product marketing .claude/agents/
 
-# Global (available in all projects)
+# Global install (available in all projects)
 mkdir -p ~/.claude/agents
-cp agents/*.md ~/.claude/agents/
+cp -r engineering product marketing ~/.claude/agents/
 ```
 
 ## Example Usage
 
-Paste an agent's Markdown content as your system prompt, then interact normally:
+Reference an agent in Claude Code or paste it as a system prompt:
 
 ```
-# You are the AI Engineer agent from the Claude Agents Library...
-[paste agent content here]
-
-User: Help me design a RAG pipeline for a legal document search system.
+Acting as the AI Engineer agent, design a RAG pipeline for legal document search.
 ```
 
 ## Repository

--- a/agents/aiagentskit__claude-agents-library/README.md
+++ b/agents/aiagentskit__claude-agents-library/README.md
@@ -1,0 +1,62 @@
+# Claude Agents Library
+
+**34 production-ready Claude agent configurations** organised across 7 professional
+categories, ready to copy-paste as system prompts or drop into Claude Code's
+`.claude/agents/` directory.
+
+## What It Does
+
+The Claude Agents Library gives you a curated roster of specialist AI personas —
+each one a deeply-configured Markdown file that transforms Claude into a domain
+expert with consistent behaviour, defined responsibilities, and example prompts.
+
+Instead of starting from a blank system prompt every time, you grab the agent
+that matches your task, paste it in, and get a senior specialist.
+
+## Categories & Agents
+
+| Category | Agents |
+|---|---|
+| **Design** (5) | Brand Guardian, UX Researcher, Visual Designer, Motion Designer, Design System Architect |
+| **Engineering** (6) | AI Engineer, Backend Architect, DevOps Automator, Frontend Developer, Mobile App Builder, Rapid Prototyper |
+| **Marketing** (7) | App Store Optimizer, Content Strategist, Growth Hacker, SEO Specialist, Social Media Manager, Email Marketer, Campaign Analyst |
+| **Product** (3) | Feedback Synthesizer, Product Roadmapper, Competitive Analyst |
+| **Project Management** (3) | Sprint Planner, Retrospective Facilitator, Risk Manager |
+| **Studio Operations** (5) | Client Relations Manager, Resource Planner, Process Documenter, Billing Specialist, Onboarding Guide |
+| **Testing** (5) | API Tester, QA Strategist, Performance Tester, Accessibility Auditor, Security Scanner |
+
+## Key Features
+
+- **v1.2 — 34 agents** across 7 professional categories
+- **Copy-paste ready** — each agent ships with purpose, responsibilities, skills, communication style, and example prompts
+- **Claude Code compatible** — drop agents into `.claude/agents/` for auto-discovery
+- **MCP integration patterns** — 7 ready-made workflows with code examples
+- **Model selection matrix** — 30+ task-specific recommendations with cost comparisons
+- **Cost optimisation** — up to 82% savings with guidance on Haiku vs. Sonnet vs. Opus
+
+## Quick Start
+
+```bash
+# Project-specific
+mkdir -p .claude/agents
+cp agents/engineering/ai-engineer.md .claude/agents/
+
+# Global (available in all projects)
+mkdir -p ~/.claude/agents
+cp agents/*.md ~/.claude/agents/
+```
+
+## Example Usage
+
+Paste an agent's Markdown content as your system prompt, then interact normally:
+
+```
+# You are the AI Engineer agent from the Claude Agents Library...
+[paste agent content here]
+
+User: Help me design a RAG pipeline for a legal document search system.
+```
+
+## Repository
+
+https://github.com/aiagentskit/claude-agents-library

--- a/agents/aiagentskit__claude-agents-library/metadata.json
+++ b/agents/aiagentskit__claude-agents-library/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-agents-library",
+  "author": "aiagentskit",
+  "description": "34 production-ready Claude agent configurations across 7 professional categories: design, engineering, marketing, product, project management, studio ops, and testing.",
+  "repository": "https://github.com/aiagentskit/claude-agents-library",
+  "version": "1.2.0",
+  "category": "productivity",
+  "tags": ["claude", "agents", "system-prompt", "engineering", "marketing", "design", "testing", "product", "devops"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}

--- a/agents/aiagentskit__claude-agents-library/metadata.json
+++ b/agents/aiagentskit__claude-agents-library/metadata.json
@@ -1,14 +1,13 @@
 {
   "name": "claude-agents-library",
   "author": "aiagentskit",
-  "description": "34 production-ready Claude agent configurations across 7 professional categories: design, engineering, marketing, product, project management, studio ops, and testing.",
+  "description": "34 production-ready Claude agent configs across 7 domains: engineering, marketing, design, product, project-management, studio-operations, and testing. Drop-in for Claude Code.",
   "repository": "https://github.com/aiagentskit/claude-agents-library",
   "version": "1.2.0",
-  "category": "productivity",
-  "tags": ["claude", "agents", "system-prompt", "engineering", "marketing", "design", "testing", "product", "devops"],
+  "category": "developer-tools",
+  "tags": ["claude", "agents", "system-prompt", "engineering", "marketing", "design", "testing", "product", "claude-code"],
   "license": "MIT",
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "anthropic:claude-sonnet-4-6",
   "adapters": ["claude-code", "system-prompt"],
-  "icon": false,
-  "banner": false
+  "icon": false
 }


### PR DESCRIPTION
Adds **claude-agents-library** by @aiagentskit to the GAP registry. 

**Repo:** https://github.com/aiagentskit/claude-agents-library  
**Category:** `developer-tools`  
**Tags:** claude, agents, system-prompt, engineering, marketing, design, testing, product, claude-code

**About the agent:** 34 production-ready Claude agent configurations across 7 professional domains — engineering, marketing, design, product, project-management, studio-operations, and testing. Each agent is a focused persona drop-in for Claude Code (`.claude/agents/`) or any system-prompt-compatible runtime (v1.2.0, MIT).

**GAP files status:** `agent.yaml` + `SOUL.md` proposed via PR #3 on the target repo (https://github.com/aiagentskit/claude-agents-library/pull/3 — open, awaiting merge). The registry entry points to the main branch; the CI check will pass once the maintainer merges the adoption PR.

**What changed in this update:** corrected agent names, improved README accuracy, tightened description to <200 chars, set category to `developer-tools`.

---

⭐ If GAP looks useful to you, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.