### PR TITLE
Add Integuru-AI/integuru

### DIFF
--- a/agents/Integuru-AI__integuru/README.md
+++ b/agents/Integuru-AI__integuru/README.md
@@ -1,0 +1,40 @@
+# Integuru
+
+**Integuru** is an AI agent that builds permissionless integrations by reverse-engineering the internal APIs of any web platform — even platforms that publish no official API.
+
+## What It Does
+
+Point Integuru at a browser session (HAR file + cookies) and describe the action you want to automate. Integuru will:
+
+1. **Identify the target endpoint** — from hundreds of captured requests, it finds the one responsible for your described action using LLM reasoning.
+2. **Build a dependency graph** — dynamic values (session tokens, account IDs, CSRF tokens) are traced back recursively to their source requests, forming a Directed Acyclic Graph (DAG).
+3. **Generate runnable Python code** — each node in the DAG becomes a Python function; the full traversal reproduces the authenticated action end-to-end.
+
+## Key Capabilities
+
+- HAR file parsing and network request/response analysis
+- LLM-driven dynamic-part identification (tokens, IDs, session variables)
+- Recursive dependency graph construction
+- Clean Python code generation with no manual curl-wrangling
+- Support for 2FA-protected platforms (capture cookies post-2FA)
+- Input variable substitution (e.g., parameterise the year in a document download)
+
+## Example Usage
+
+\`\`\`bash
+# Capture browser session
+poetry run python create_har.py
+
+# Run the agent
+poetry run integuru --prompt "download utility bills" --model gpt-4o
+\`\`\`
+
+## Models
+
+- Primary: **GPT-4o** (graph building, function calling)
+- Fallback: **o1-preview** (code generation)
+
+## Links
+
+- GitHub: https://github.com/Integuru-AI/Integuru
+- Live product: https://www.integuru.com

--- a/agents/Integuru-AI__integuru/metadata.json
+++ b/agents/Integuru-AI__integuru/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "integuru",
+  "author": "Integuru-AI",
+  "description": "AI agent that reverse-engineers internal platform APIs via HAR analysis, builds request dependency graphs, and generates runnable Python integration code — no official API needed.",
+  "repository": "https://github.com/computer-agent/Integuru",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["api-automation", "har-analysis", "reverse-engineering", "rpa", "integration", "dependency-graph", "openai", "gpt-4o", "unofficial-api", "code-generation"],
+  "license": "AGPL-3.0",
+  "model": "gpt-4o",
+  "adapters": ["openai", "system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **Integuru** by Integuru-AI to the Open GAP registry.

**What it does:** Integuru is an AI agent that reverse-engineers internal platform APIs by parsing browser HAR files, building a dependency graph of dynamic requests, and generating runnable Python integration code — enabling automation against platforms with no official API.

**Details:**
- Repo: https://github.com/Integuru-AI/Integuru (4,600+ ⭐)
- Category: `developer-tools`
- Tags: api-automation, har-analysis, reverse-engineering, rpa, integration, dependency-graph, openai, gpt-4o, unofficial-api, code-generation
- License: AGPL-3.0
- Model: GPT-4o (with o1-preview fallback)
- GAP files (`agent.yaml` + `SOUL.md`): proposed to upstream via [Integuru-AI/Integuru#71](https://github.com/Integuru-AI/Integuru/pull/71) — files are live on the fork at https://github.com/computer-agent/Integuru (which the CI validator will use until the upstream PR merges)

---

⭐ If this standard looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover it.