### PR TITLE
Add gadievron/raptor — autonomous security research agent

### DIFF
--- a/agents/gadievron__raptor/README.md
+++ b/agents/gadievron__raptor/README.md
@@ -1,0 +1,48 @@
+# RAPTOR — Autonomous Security Research Framework
+
+**RAPTOR** (Recursive Autonomous Penetration Testing and Observation Robot) is an autonomous
+offensive/defensive security research framework built on top of Claude Code. It chains together
+static analysis, binary analysis, LLM-powered vulnerability validation, exploit generation, and
+patch writing into a single end-to-end workflow.
+
+Point it at a codebase or binary and it hunts, validates, and reports exploitable vulnerabilities
+— with full project management, multi-model consensus, and forensic-grade evidence handling.
+
+## Key Capabilities
+
+- **`/scan`** — Semgrep + language-specific static analysis
+- **`/agentic`** — Full autonomous pipeline: scan → dedup → LLM analysis → validation
+- **`/fuzz`** — Fuzzing campaigns
+- **`/codeql`** — CodeQL dataflow and taint analysis with SMT-based path validation
+- **`/validate`** — Staged exploitability validation pipeline (inventory → reachability → mitigation check → PoC)
+- **`/understand`** — Adversarial code comprehension (map attack surface, trace data flows, hunt variants)
+- **`/crash-analysis`** — Autonomous root-cause analysis for C/C++ crashes using deterministic record-replay (rr)
+- **`/oss-forensics`** — Evidence-backed forensic investigation of public GitHub repositories
+- **`/exploit`** — Proof-of-concept exploit generation
+- **`/patch`** — Fix generation for confirmed vulnerabilities
+- **`/diagram`** — Mermaid visual maps from analysis outputs (attack trees, data flow graphs)
+
+## Philosophy
+
+RAPTOR thinks like an attacker and a defender simultaneously. It is honest about exploitability
+(`Unlikely` / `Difficult` / `Likely Exploitable`) and always offers next steps. Safe operations
+(scan, read, generate) proceed autonomously; destructive operations (apply patches, git push)
+require human confirmation.
+
+## Quick Start
+
+```bash
+git clone https://github.com/gadievron/raptor.git
+cd raptor
+# Set up Claude Code with the repo as working directory
+# Run: /agentic --target /path/to/target-codebase
+```
+
+## Authors
+
+Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake), Michael Bargury, John Cartwright
+
+## Links
+
+- Repository: https://github.com/gadievron/raptor
+- License: MIT (CodeQL has its own license — no commercial use)

--- a/agents/gadievron__raptor/metadata.json
+++ b/agents/gadievron__raptor/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "raptor",
+  "author": "gadievron",
+  "description": "Autonomous offensive/defensive security research framework on Claude Code — chains static analysis, CodeQL, fuzzing, LLM-powered vuln validation, exploit generation, and patch writing.",
+  "repository": "https://github.com/computer-agent/raptor",
+  "path": "",
+  "version": "3.0.0",
+  "category": "security",
+  "tags": ["security", "penetration-testing", "vulnerability-research", "static-analysis", "fuzzing", "codeql", "exploit", "autonomous", "claude-code"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **RAPTOR** by [@gadievron](https://github.com/gadievron) to the registry.

Repo: https://github.com/gadievron/raptor — **2,800+ stars**, MIT license.

**What RAPTOR does:** An autonomous offensive/defensive security research framework built on Claude Code. Chains Semgrep, CodeQL, AFL++ fuzzing, web scanning, LLM-powered vulnerability validation, exploit generation, and patch writing into a single agentic pipeline. Used for authorized penetration testing and defensive security research.

**Category:** `security`
**Tags:** security, penetration-testing, fuzzing, static-analysis, codeql, semgrep, exploit, vulnerability, claude-code, autonomous-agent
**Adapters:** claude-code, system-prompt

**Note on CI:** `agent.yaml` + `SOUL.md` are being proposed to the upstream repo in [PR #705](https://github.com/gadievron/raptor/pull/705). The local CI check flags this because the files aren't on the default branch yet — once that PR merges, registry CI will pass cleanly. Happy to coordinate the merge order if helpful.

---

⭐ If the GitAgent Protocol looks useful for your ecosystem, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more security tooling maintainers discover it.