### PR TITLE
Add flepied/second-brain-agent

### DIFF
--- a/agents/flepied__second-brain-agent/README.md
+++ b/agents/flepied__second-brain-agent/README.md
@@ -1,0 +1,63 @@
+# Second Brain Agent 🧠
+
+A **Personal Knowledge Management AI agent** that turns your scattered markdown notes into a searchable, conversational knowledge base — inspired by Tiago Forte's *Building a Second Brain* methodology.
+
+## What It Does
+
+Second Brain Agent watches your markdown note directory and automatically ingests everything it finds:
+
+- 📝 **Markdown files** — extracted text and metadata
+- 📄 **PDFs** — local and remote (including arXiv papers)
+- 🎥 **YouTube videos** — auto-transcribed and indexed
+- 🌐 **Web pages** — fetched and chunked for semantic search
+- 🔗 **File URLs** — any linked local document
+
+All content is broken into chunks, embedded with HuggingFace sentence-transformers, and stored in a local **ChromaDB** vector database — entirely on your machine.
+
+## Key Capabilities
+
+| Capability | Detail |
+|---|---|
+| **Semantic Search** | Ask questions in natural language; the agent finds the most relevant chunks across all your notes |
+| **Domain Filtering** | Automatically classifies notes by domain (Work, Personal, Workout, etc.) from filename conventions |
+| **Journal Awareness** | Handles date-structured journal entries for temporal queries (`## 02 Dec 2024`) |
+| **MCP Server** | Exposes the vector DB via Model Context Protocol — plug any MCP-compatible LLM into your notes |
+| **Smart Connections** | Surfaces non-obvious relationships between notes |
+
+## Example Usage
+
+```bash
+# Index your Obsidian vault
+SRCDIR=~/Documents/MyNotes DSTDIR=~/sba-data uv run python transform_md.py
+
+# Start the MCP server (then connect your LLM client)
+uv run python mcp_server.py
+
+# Query via CLI
+uv run python qa.py "What did I learn about systems thinking last month?"
+```
+
+## Setup
+
+```bash
+# Clone and install
+git clone https://github.com/flepied/second-brain-agent.git
+cd second-brain-agent
+cp example.env .env   # fill in your API keys
+uv install
+```
+
+**Required env vars:** `OPENAI_API_KEY`, `HUGGINGFACEHUB_API_TOKEN`, `SRCDIR`, `DSTDIR`  
+**Optional:** `ASSEMBLYAI_API_KEY` for higher-quality transcription
+
+## Stack
+
+- **LangChain** — orchestration
+- **ChromaDB** — local vector store
+- **FastMCP** — MCP server
+- **HuggingFace sentence-transformers** — embeddings
+- **OpenAI** — answer generation (GPT-4o by default)
+
+## Protocol
+
+This agent conforms to the [GitAgent Protocol](https://gitagent.sh) — see [`agent.yaml`](https://github.com/flepied/second-brain-agent/blob/main/agent.yaml) and [`SOUL.md`](https://github.com/flepied/second-brain-agent/blob/main/SOUL.md).

--- a/agents/flepied__second-brain-agent/metadata.json
+++ b/agents/flepied__second-brain-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "second-brain-agent",
+  "author": "flepied",
+  "description": "Personal Knowledge Management AI agent that indexes markdown notes, PDFs, YouTube videos, and web pages into a vector DB and answers questions via MCP.",
+  "repository": "https://github.com/flepied/second-brain-agent",
+  "version": "0.7.0",
+  "category": "productivity",
+  "tags": ["personal-knowledge-management", "second-brain", "langchain", "chromadb", "mcp", "rag", "notes", "obsidian"],
+  "license": "GPL-3.0",
+  "model": "openai:gpt-4o",
+  "adapters": ["system-prompt", "openai"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **second-brain-agent** by [@flepied](https://github.com/flepied) to the Open GAP registry.

**Repo:** https://github.com/flepied/second-brain-agent  
**Category:** productivity  
**Tags:** personal-knowledge-management, second-brain, langchain, chromadb, mcp, rag, notes, obsidian

**What the agent does:** Automatically indexes markdown notes and their linked content (PDFs, YouTube videos, web pages) into a local ChromaDB vector database and exposes it via an MCP server — so any LLM can answer questions across your entire personal knowledge base. Built on LangChain + OpenAI, inspired by Tiago Forte's Second Brain methodology.

**GAP files:** A PR adding `agent.yaml` + `SOUL.md` is open upstream at https://github.com/flepied/second-brain-agent/pull/64. Once merged, the registry CI's repo check will pass on the default branch.

---

If GAP looks useful to you, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.