### PR TITLE
Add ilyasibrahim/claude-agents-coordination

### DIFF
--- a/agents/ilyasibrahim__claude-agents-coordination/README.md
+++ b/agents/ilyasibrahim__claude-agents-coordination/README.md
@@ -1,0 +1,67 @@
+# Claude Agents Coordination
+
+A **production-grade multi-agent coordination system** for Claude Code that solves three
+critical problems in long-running agent workflows:
+
+1. **Context amnesia** — agents forget prior work within 15–20 minutes
+2. **Coordination chaos** — multiple agents overwriting each other's output
+3. **Delegation limits** — manual oversight required for every routing decision
+
+## Architecture
+
+### Tiered Agent System
+
+| Tier | Agents | Role |
+|------|--------|------|
+| 1 — Orchestrators | code-quality, test-engineer, architect, ml-engineer | End-to-end workflow ownership |
+| 2 — Specialists | security-engineer, sre, rfc, data-engineer, frontend, backend, devops, docs | Focused execution |
+| 3 — On-demand | lrl-nlp-expert, data-viz-specialist, ux-designer | Deep domain expertise |
+
+### Dual-Registry Model
+
+- **`_registry.md`** — Institutional memory: what was done, what was delivered, what is next.
+- **`_tech-debt.md`** — Explicit debt ledger: every shortcut logged with severity, source, and remediation plan.
+
+### 4-Step Coordination Protocol
+
+1. **Registry Check** — restore context before any task
+2. **Context Injection** — distribute relevant history to sub-agents
+3. **Sequencing** — parallel or sequential execution per dependency order
+4. **Verification** — quality gates (lint, type-check, test, OWASP) before marking done
+
+## Key Commands
+
+| Command | What it does |
+|---------|-------------|
+| `/review-full <path>` | Multi-level code review (L1 peer → L4 reliability) |
+| `/ci` | Full local quality gate before pushing |
+| `/debt` | View and manage tech-debt registry |
+| `/rfc <topic>` | Create and manage RFC design documents |
+| `/postmortem <incident>` | Structured incident review with auto debt logging |
+
+## Quick Start
+
+```bash
+# Install user-level config (agents, commands, skills)
+mkdir -p ~/.claude && rsync -a claude-user/ ~/.claude/
+
+# Install project-level config (memory, registries, project commands)
+mkdir -p .claude && rsync -a claude-project/ .claude/
+```
+
+Then open Claude Code and run `/review-full src/` or `/ci` to see the system in action.
+
+## Performance
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Productive session length | ~15–20 min | 2+ hours |
+| Protocol token overhead | 370 lines (always) | 150–250 lines (selective) |
+| Review depth | Single-level | L1 → L4 graduated escalation |
+| Tech-debt visibility | None | Explicit ledger |
+
+## Resources
+
+- **Repo**: https://github.com/ilyasibrahim/claude-agents-coordination
+- **Article series**: https://medium.com/@ilyas.ibrahim
+- **License**: Unlicense (public domain)

--- a/agents/ilyasibrahim__claude-agents-coordination/metadata.json
+++ b/agents/ilyasibrahim__claude-agents-coordination/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-agents-coordination",
+  "author": "ilyasibrahim",
+  "description": "Production-grade multi-agent coordination for Claude Code: tiered delegation, dual-registry institutional memory, multi-level review chains, and explicit tech-debt tracking.",
+  "repository": "https://github.com/ilyasibrahim/claude-agents-coordination",
+  "version": "2.3.0",
+  "category": "developer-tools",
+  "tags": ["multi-agent", "claude-code", "coordination", "orchestration", "institutional-memory", "tech-debt", "code-review", "delegation"],
+  "license": "Unlicense",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **claude-agents-coordination** by [@ilyasibrahim](https://github.com/ilyasibrahim) to the registry.

**Repository:** https://github.com/ilyasibrahim/claude-agents-coordination  
**Category:** developer-tools  
**Tags:** multi-agent, claude-code, coordination, memory, tech-debt, orchestration, delegation, devops, code-review, agents

This is a production-grade multi-agent coordination system for Claude Code — 15 specialised agents across three tiers, a 4-step coordination protocol, dual-registry institutional memory (completed work + tech debt), and standard slash commands (/review-full, /ci, /debt, /postmortem, /rfc). It solves context amnesia and coordination chaos in long-running agent sessions.

A companion PR adding `agent.yaml` + `SOUL.md` is open at https://github.com/ilyasibrahim/claude-agents-coordination/pull/4 — registry CI will validate once those files land on the default branch.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.