### PR TITLE
Add raroque/boop-agent

### DIFF
--- a/agents/raroque__boop-agent/README.md
+++ b/agents/raroque__boop-agent/README.md
@@ -1,0 +1,57 @@
+# Boop — iMessage Personal AI Agent
+
+**Boop** is a personal AI agent you text from iMessage. It uses the Claude Agent SDK (or Codex/ChatGPT runtime) and runs on your existing subscription — no separate API key needed.
+
+## What it does
+
+Boop is built around a **dispatcher + workers** pattern:
+
+- A lean **interaction agent** reads your iMessage, recalls relevant memories, then decides: answer directly (greetings, clarifications) or spawn a focused sub-agent (anything that needs the real world).
+- **Execution sub-agents** are spawned per task. Each gets a crisp job description, runs WebSearch/WebFetch and any integrations you've connected, then returns a concise result the interaction agent relays in its own warm voice.
+
+## Key capabilities
+
+| Feature | Detail |
+|---|---|
+| **Tiered memory** | Short / long / permanent tiers with decay + daily adversarial consolidation |
+| **Automations** | Schedule recurring tasks from plain text ("every morning at 8, summarise my calendar") |
+| **Draft-and-confirm** | Any irreversible action (send email, post Slack) is staged as a draft first |
+| **Composio integrations** | One API key → 1000+ toolkits: Gmail, Slack, GitHub, Notion, Linear, Stripe, Supabase, etc. |
+| **Optional browser use** | Local Patchright Chrome for login-only portals and JS-heavy services |
+| **Debug dashboard** | React + Vite UI — Agents, Automations, Memory graph, Connections |
+| **Vector search** | Embedding-backed recall (Voyage / OpenAI), falls back to substring |
+
+## Architecture
+
+```
+iMessage → Sendblue webhook → Interaction agent → Execution agent(s)
+                                      │                  │
+                                      ▼                  ▼
+                               Convex (memory,    Composio / MCP tools
+                               automations,       WebSearch / WebFetch
+                               drafts, logs)      Optional local browser
+```
+
+## Getting started
+
+```bash
+git clone https://github.com/raroque/boop-agent.git
+cd boop-agent
+npm install
+# Follow the setup wizard:
+npm run setup
+```
+
+You'll need accounts for: Claude Code (or Codex), Sendblue (iMessage bridge), Convex (database), and optionally Composio (integrations).
+
+## Example interactions
+
+> **You:** "Add a reminder to call my dentist next Tuesday at 3pm"  
+> **Boop:** "Done — I'll nudge you Tuesday at 3 PM. Your dentist is Dr. Chen, right?"
+
+> **You:** "Every weekday at 9am, pull my top 3 emails and summarise them"  
+> **Boop:** "Automation created. I'll boop you at 9 AM on weekdays with your morning inbox snapshot."
+
+## License
+
+MIT — template/starter project, open for extension.

--- a/agents/raroque__boop-agent/metadata.json
+++ b/agents/raroque__boop-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "boop-agent",
+  "author": "raroque",
+  "description": "iMessage personal AI agent: dispatcher + sub-agents with tiered memory, automations, draft-and-confirm, and 1000+ Composio integrations.",
+  "repository": "https://github.com/raroque/boop-agent",
+  "version": "0.2.0",
+  "category": "productivity",
+  "tags": ["imessage", "personal-agent", "memory", "automations", "composio", "claude", "sub-agents"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **boop-agent** by [@raroque](https://github.com/raroque) to the registry.

**Repo:** https://github.com/raroque/boop-agent  
**Category:** productivity  
**Tags:** imessage, personal-agent, memory, automations, composio, claude, sub-agents

Boop is an iMessage-based personal AI agent with a dispatcher + sub-agents architecture, tiered memory with daily consolidation, scheduled automations, draft-and-confirm for irreversible actions, and 1000+ Composio integrations — running on your Claude Code or Codex subscription with no separate API key required.

The GAP files (`agent.yaml` + `SOUL.md`) are proposed in **[raroque/boop-agent#65](https://github.com/raroque/boop-agent/pull/65)** and will be on the default branch once that PR merges. The registry CI will pass at that point.

---

⭐ If the standard looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.