### PR TITLE
Add solanabr/solana-claude

### DIFF
--- a/agents/solanabr__solana-claude/README.md
+++ b/agents/solanabr__solana-claude/README.md
@@ -1,0 +1,81 @@
+# solana-claude
+
+**Production-ready Claude Code configuration for full-stack Solana blockchain development.**
+
+`solana-claude` turns any Claude (or compatible) LLM into an expert Solana builder with deep knowledge spanning on-chain programs, DeFi protocols, frontend dApps, mobile (Solana Mobile SDK), Unity games, security auditing, and DevOps. It ships a battle-tested configuration you drop into any Solana project with a single `curl` command.
+
+---
+
+## What it does
+
+- **15 specialized sub-agents** — each loaded on-demand to keep context lean:
+  `solana-architect`, `anchor-engineer`, `pinocchio-engineer`, `defi-engineer`,
+  `solana-frontend-engineer`, `mobile-engineer`, `unity-engineer`,
+  `rust-backend-engineer`, `devops-engineer`, `solana-qa-engineer`,
+  `token-engineer`, `tech-docs-writer`, `solana-researcher`, `game-architect`,
+  `solana-guide`
+
+- **24 workflow commands** — `/quick-commit`, `/audit-solana`, `/profile-cu`,
+  `/diff-review`, `/setup-mcp`, `/cleanup`, and more — covering build, deploy,
+  test, profile, and commit workflows
+
+- **6 MCP server integrations** — Helius (60+ RPC/DAS tools), Solana Foundation
+  official docs, Context7 (library docs), Playwright (dApp e2e testing),
+  context-mode (response compression), memsearch (persistent semantic memory)
+
+- **Progressive skill loading** — 10 external submodules (Solana Foundation,
+  SendAI, Trail of Bits, Vercel, Cloudflare, QEDGen, Colosseum, and more) loaded
+  only when relevant, keeping the base context under 120 lines
+
+- **Security-first** — enforced rules: checked arithmetic everywhere, full
+  account validation, devnet-before-mainnet deploy gates, CU profiling,
+  verifiable builds for mainnet
+
+---
+
+## Quick Start
+
+```bash
+# Option 1: One-liner (Claude Code)
+curl -fsSL https://raw.githubusercontent.com/solanabr/solana-claude/main/install.sh | bash
+
+# Option 2: Non-Claude runtimes (Cursor, Windsurf, Codex, etc.)
+curl -fsSL https://raw.githubusercontent.com/solanabr/solana-claude/main/install.sh | bash -s -- --agents
+
+# Option 3: Manual
+git clone --recurse-submodules https://github.com/solanabr/solana-claude.git
+cp -r solana-claude/.claude /path/to/your-project/
+cp solana-claude/CLAUDE-solana.md /path/to/your-project/CLAUDE.md
+```
+
+Then start Claude Code (`claude`) and the full agent configuration is live.
+
+---
+
+## Example usage
+
+```
+# In Claude Code, once installed:
+"I need to build a token staking program with crank-less rewards"
+→ solana-architect designs the account layout
+→ anchor-engineer implements the program
+→ solana-qa-engineer writes BankClient tests
+→ devops-engineer sets up the deploy pipeline
+
+# Security audit
+/audit-solana
+
+# CU profiling before mainnet
+/profile-cu
+
+# Smart commit with branch naming convention
+/quick-commit
+```
+
+---
+
+## Links
+
+- Repository: https://github.com/solanabr/solana-claude
+- Install docs: see `QUICK-START.md` in the repo
+- License: MIT

--- a/agents/solanabr__solana-claude/metadata.json
+++ b/agents/solanabr__solana-claude/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "solana-claude",
+  "author": "solanabr",
+  "description": "Production-ready Claude Code config turning any LLM into an expert full-stack Solana developer — 15 sub-agents, 24 commands, 6 MCP integrations, security-first.",
+  "repository": "https://github.com/solanabr/solana-claude",
+  "path": "",
+  "version": "1.5.0",
+  "category": "developer-tools",
+  "tags": ["solana", "blockchain", "web3", "anchor", "rust", "defi", "claude-code", "smart-contracts", "pinocchio", "multi-agent"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **solana-claude** by [@solanabr](https://github.com/solanabr) to the Open GAP registry.

**Repo:** https://github.com/solanabr/solana-claude
**Category:** `developer-tools`
**Tags:** `solana`, `blockchain`, `anchor`, `web3`, `defi`, `smart-contracts`, `rust`, `claude-code`, `pinocchio`, `spl-token`

**What this agent does:** Production-ready Claude Code configuration that turns Claude into an expert full-stack Solana developer — 15 specialised sub-agents (architect, Anchor, Pinocchio, DeFi, tokens, frontend, mobile, backend, DevOps, QA, docs, games, Unity, guide, researcher), 24 workflow commands, 6 MCP server integrations (Helius, solana-dev, Context7, Playwright, context-mode, memsearch), progressive skill loading, and built-in security guardrails that require explicit confirmation before any mainnet deployment.

**GAP files status:** A PR adding `agent.yaml` + `SOUL.md` to the target repo is open at https://github.com/solanabr/solana-claude/pull/9. The registry CI check (which clones main) will pass once that PR is merged. Both PRs are ready for the maintainer to review together.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more Solana builders discover the standard.