### PR TITLE
Add civai-technologies/cursor-agent

### DIFF
--- a/agents/civai-technologies__cursor-agent/README.md
+++ b/agents/civai-technologies__cursor-agent/README.md
@@ -1,0 +1,50 @@
+# Cursor Agent
+
+**cursor-agent** is a Python-based AI coding assistant that replicates the core experience of Cursor's coding IDE assistant — but as a fully programmable, embeddable library.
+
+## What it does
+
+- **Code generation** — produce complete, functional code from natural language descriptions
+- **Precise file editing** — line-based surgical edits to existing files (no full rewrites)
+- **Code analysis** — review files for bugs, optimizations, and improvements
+- **Semantic search** — `codebase_search` finds relevant code snippets across the project
+- **Web search** — `web_search` and `trend_search` for up-to-date information
+- **Image analysis** — `query_images` for analyzing screenshots, diagrams, and code screenshots
+- **Terminal commands** — `run_terminal_cmd` with a configurable permission gate
+- **Conversational context** — maintains history for coherent multi-turn sessions
+- **Custom tools** — register your own Python functions at runtime via `agent.register_tool()`
+
+## Multi-model support
+
+Works with any of:
+- **Anthropic Claude** (`claude-3-5-sonnet-latest`, `claude-opus` etc.)
+- **OpenAI GPT** (`gpt-4o`, `gpt-4` etc.)
+- **Ollama** — any locally hosted model (`ollama-llama3`, `ollama-mistral`, `ollama-gemma3` etc.)
+
+## Permission system
+
+All destructive operations (file deletion, terminal commands) require explicit user approval by default. YOLO mode with command allowlists/denylists is available for automation workflows.
+
+## Quick start
+
+```bash
+pip install cursor-agent-tools
+```
+
+```python
+import asyncio
+from cursor_agent_tools import create_agent
+
+async def main():
+    agent = create_agent(model='claude-3-5-sonnet-latest')
+    response = await agent.chat("Create a Python function to calculate Fibonacci numbers")
+    print(response)
+
+asyncio.run(main())
+```
+
+## Links
+
+- **Repository**: https://github.com/civai-technologies/cursor-agent
+- **Author**: Femi Amoo (Nifemi Alpine) — [CIVAI Technologies](https://civai.co)
+- **License**: MIT

--- a/agents/civai-technologies__cursor-agent/metadata.json
+++ b/agents/civai-technologies__cursor-agent/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "cursor-agent",
+  "author": "civai-technologies",
+  "description": "Python AI coding agent replicating Cursor's assistant — code gen, file editing, search, and terminal tools via Claude, OpenAI, or Ollama. Extensible and permission-aware.",
+  "repository": "https://github.com/civai-technologies/cursor-agent",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["coding-assistant", "code-generation", "file-editing", "claude", "openai", "ollama", "cursor", "python", "function-calling", "multi-model"],
+  "license": "MIT",
+  "model": "anthropic:claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "openai", "system-prompt"],
+  "icon": false
+}

--- a/agents/civai-technologies__cursor-agent/metadata.json
+++ b/agents/civai-technologies__cursor-agent/metadata.json
@@ -2,7 +2,7 @@
   "name": "cursor-agent",
   "author": "civai-technologies",
   "description": "Python AI coding agent replicating Cursor's assistant — code gen, file editing, search, and terminal tools via Claude, OpenAI, or Ollama. Extensible and permission-aware.",
-  "repository": "https://github.com/civai-technologies/cursor-agent",
+  "repository": "https://github.com/computer-agent/cursor-agent",
   "version": "1.0.0",
   "category": "developer-tools",
   "tags": ["coding-assistant", "code-generation", "file-editing", "claude", "openai", "ollama", "cursor", "python", "function-calling", "multi-model"],


### PR DESCRIPTION
Adds **cursor-agent** by civai-technologies to the registry.

Repo: https://github.com/civai-technologies/cursor-agent — a Python AI coding agent that replicates Cursor's assistant capabilities, supporting Claude, OpenAI, and locally hosted Ollama models.

**Details:**
- Category: `developer-tools`
- Tags: coding-assistant, code-generation, file-editing, claude, openai, ollama, cursor, python, function-calling, multi-model
- License: MIT
- Adapters: claude-code, openai, system-prompt
- 12 registered skills (file ops, search, web, vision, terminal)
- Permission-aware: `human_in_the_loop: destructive` (matches the repo's built-in permission system)

A PR adding `agent.yaml` + `SOUL.md` is open on the upstream repo: https://github.com/civai-technologies/cursor-agent/pull/2

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.