### PR TITLE
Add TilmanGriesel/chipper

### DIFF
--- a/agents/TilmanGriesel__chipper/README.md
+++ b/agents/TilmanGriesel__chipper/README.md
@@ -1,0 +1,53 @@
+# Chipper
+
+**Chipper** is a modular, hackable, privacy-first RAG (Retrieval-Augmented Generation) agent platform for tinkerers, educators, and builders who want powerful local LLM workflows without sending data to the cloud.
+
+---
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/TilmanGriesel/chipper
+```
+
+---
+
+## What It Can Do
+
+| Skill | Description |
+|---|---|
+| **RAG Query** | Answer questions grounded in your documents via ElasticSearch vector retrieval |
+| **Document Embed** | Chunk and vectorize documents into the knowledge base |
+| **Web Scrape** | Extract and index content from web pages |
+| **Audio Transcribe** | Convert audio files to text and index the transcript |
+| **Ollama API Proxy** | Proxy any Ollama client request with server-side RAG and system prompt injection |
+
+---
+
+## Key Features
+
+- **Local & Cloud Models** — Run models via [Ollama](https://ollama.com/) locally or connect to [Hugging Face](https://huggingface.co/) API
+- **ElasticSearch Integration** — Scalable, vectorized document storage and retrieval
+- **Fully Dockerized** — One `docker compose up` and it's running
+- **Ollama API Compatible** — Works as a drop-in proxy for Enchanted, Open WebUI, Ollamac, and the Ollama CLI
+- **Offline Web UI** — Built with vanilla JS + TailwindCSS, no internet required
+- **Edge TTS** — Listen to responses using WebAssembly-based client-side TTS
+- **Distributed Processing** — Chain multiple Chipper instances together
+
+## Why Chipper?
+
+Chipper was born from a real need: to help explore a book's characters and ideas using local LLMs, keeping private creative work entirely off the cloud. That origin gives it a clear soul — **privacy-first, approachable, and built to be forked**.
+
+**Live demo:** https://demo.chipper.tilmangriesel.com/
+**Project site:** https://chipper.tilmangriesel.com/
+
+## Setup
+
+```bash
+git clone https://github.com/TilmanGriesel/chipper.git
+cd chipper
+python setup.py          # interactive setup
+docker compose up -d     # launch all services
+```
+
+See the [full setup guide](https://chipper.tilmangriesel.com/get-started.html) for detailed instructions.

--- a/agents/TilmanGriesel__chipper/metadata.json
+++ b/agents/TilmanGriesel__chipper/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "chipper",
+  "author": "TilmanGriesel",
+  "description": "Hackable, privacy-first RAG agent platform — local LLMs via Ollama, ElasticSearch vector store, doc chunking, web scraping, audio transcription, and an Ollama API proxy with server-side RAG injection.",
+  "repository": "https://github.com/computer-agent/chipper",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["rag", "ollama", "local-llm", "haystack", "elasticsearch", "privacy", "docker", "tinkerer", "knowledge-base", "ollama-proxy"],
+  "license": "MIT",
+  "model": "ollama:llama3",
+  "adapters": ["system-prompt", "openai"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **Chipper** by [@TilmanGriesel](https://github.com/TilmanGriesel) to the registry.

**Repo:** https://github.com/TilmanGriesel/chipper
**GAP files:** present on the pending adoption PR branch (https://github.com/TilmanGriesel/chipper/pull/155) and validated via the `computer-agent/chipper` fork.
**Category:** `developer-tools`
**Tags:** `rag`, `ollama`, `local-llm`, `haystack`, `elasticsearch`, `privacy`, `docker`, `tinkerer`, `knowledge-base`, `ollama-proxy`

Chipper is a privacy-first, fully-dockerized RAG agent platform built on Haystack + Ollama. It lets you run local LLMs with document retrieval, web scraping, audio transcription, and an Ollama API proxy — all offline, all open-source. A solid addition to the developer-tools category. Local validation: ✓ Valid.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.