### PR TITLE
Add TauricResearch/TradingAgents

### DIFF
--- a/agents/TauricResearch__trading-agents/README.md
+++ b/agents/TauricResearch__trading-agents/README.md
@@ -1,0 +1,71 @@
+# TradingAgents
+
+**TradingAgents** is an open-source, multi-agent LLM financial trading framework by [TauricResearch](https://github.com/TauricResearch) that replicates the collaborative dynamics of a real trading firm.
+
+## What It Does
+
+Given a ticker symbol and a date, TradingAgents orchestrates a pipeline of specialised agents that independently analyse the market and then debate their findings before the Portfolio Manager delivers a final, rated trading decision.
+
+### Agent Pipeline
+
+| Role | Responsibility |
+|------|---------------|
+| **Fundamentals Analyst** | Reads financial statements (balance sheet, cash-flow, income statement) to assess intrinsic value |
+| **Sentiment Analyst** | Aggregates StockTwits, Reddit, and news sentiment to gauge crowd mood |
+| **News Analyst** | Monitors global macro headlines and event-driven catalysts |
+| **Technical Analyst** | Applies MACD, RSI, and pattern recognition to price data |
+| **Bull Researcher** | Champions the upside case in a structured debate |
+| **Bear Researcher** | Challenges bullish assumptions and surfaces risks |
+| **Research Manager** | Synthesises the bull/bear debate into a 5-tier rated investment plan |
+| **Trader** | Converts the research plan into a concrete BUY/HOLD/SELL transaction proposal |
+| **Aggressive / Conservative / Neutral Debators** | Three-way risk debate evaluating volatility, liquidity, and position sizing |
+| **Portfolio Manager** | Final decision-maker — synthesises everything into a rated, evidence-backed decision |
+
+### Decision Scale
+
+`Buy → Overweight → Hold → Underweight → Sell`
+
+### Memory & Learning
+
+Each completed run is logged to a persistent memory file (`~/.tradingagents/memory/trading_memory.md`). On subsequent runs for the same ticker, realised returns are fetched and the Portfolio Manager receives prior decisions plus lessons learned — enabling continuous improvement.
+
+### Multi-Provider LLM Support
+
+OpenAI (GPT), Anthropic (Claude), Google (Gemini), xAI (Grok), DeepSeek, Qwen, GLM, MiniMax, OpenRouter, Ollama (local), and Azure OpenAI.
+
+## Quick Start
+
+```bash
+git clone https://github.com/TauricResearch/TradingAgents.git
+cd TradingAgents
+pip install .
+tradingagents   # interactive CLI
+```
+
+Or via Python:
+
+```python
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+ta = TradingAgentsGraph(debug=True, config=DEFAULT_CONFIG.copy())
+_, decision = ta.propagate("NVDA", "2026-01-15")
+print(decision)
+```
+
+## Research Disclaimer
+
+TradingAgents is designed for **research purposes only**. Trading performance varies with model choice, temperature, data quality, and market conditions. This is not financial, investment, or trading advice. See https://tauric.ai/disclaimer/
+
+## Citation
+
+```bibtex
+@misc{xiao2025tradingagentsmultiagentsllmfinancial,
+  title={TradingAgents: Multi-Agents LLM Financial Trading Framework},
+  author={Yijia Xiao and Edward Sun and Di Luo and Wei Wang},
+  year={2025},
+  eprint={2412.20138},
+  archivePrefix={arXiv},
+  url={https://arxiv.org/abs/2412.20138}
+}
+```

--- a/agents/TauricResearch__trading-agents/metadata.json
+++ b/agents/TauricResearch__trading-agents/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "trading-agents",
+  "author": "TauricResearch",
+  "description": "Multi-agent LLM framework simulating a trading firm: analysts, researchers, risk debators, and a portfolio manager collaborating to deliver BUY/HOLD/SELL decisions.",
+  "repository": "https://github.com/TauricResearch/TradingAgents",
+  "version": "0.2.5",
+  "category": "finance",
+  "tags": ["trading", "finance", "multi-agent", "llm", "langgraph", "equities", "risk-management", "sentiment-analysis", "technical-analysis", "fundamental-analysis"],
+  "license": "Apache-2.0",
+  "model": "openai:gpt-4o",
+  "adapters": ["system-prompt", "openai", "claude-code"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **TradingAgents** by [@TauricResearch](https://github.com/TauricResearch) to the registry.

**Repo:** https://github.com/TauricResearch/TradingAgents
**Category:** `finance`
**Tags:** `trading`, `finance`, `multi-agent`, `llm`, `langgraph`, `equities`, `risk-management`, `sentiment-analysis`, `technical-analysis`, `fundamental-analysis`

**What this agent does:**
TradingAgents is an 80k⭐ open-source framework that orchestrates a full trading-firm pipeline of specialised LLM agents — Fundamentals, Sentiment, News, and Technical analysts; Bull/Bear researchers; a Trader; three-way Risk debators; and a Portfolio Manager — to collaboratively produce evidence-backed BUY/OVERWEIGHT/HOLD/UNDERWEIGHT/SELL decisions on equities.

**GAP files status:**
A companion PR adding `agent.yaml` + `SOUL.md` to the upstream repo is open at https://github.com/TauricResearch/TradingAgents/pull/925. The registry CI validates against the default branch; once that PR is merged, CI will pass automatically. The metadata and README in this PR are ready and validated against the schema locally.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.