### PR TITLE
Add santifer/career-ops

### DIFF
--- a/agents/santifer__career-ops/README.md
+++ b/agents/santifer__career-ops/README.md
@@ -1,0 +1,63 @@
+# Career-Ops
+
+**AI-powered job search pipeline built on Claude Code.**
+
+Career-ops was built and battle-tested during a real job search that evaluated
+740+ offers, generated 100+ tailored CVs, and resulted in a Head of Applied AI
+hire. It is designed to help you find roles with genuine fit — not to flood
+inboxes with mass applications.
+
+## Key Capabilities
+
+- **Offer Evaluation** — structured A–G scoring across role fit, compensation,
+  growth, culture, risk, and legitimacy
+- **CV Generation** — ATS-optimised HTML→PDF and LaTeX/Overleaf output,
+  tailored per application
+- **Portal Scanner** — zero-LLM-cost scan of 45+ Greenhouse/Ashby/Lever APIs
+  to surface new openings
+- **Batch Processing** — parallel lightweight scoring of many offers at once
+- **Application Pipeline** — from inbox URL to scored report to PDF in one pass
+- **Interview Prep** — company-specific intel reports + STAR+R story bank
+- **LinkedIn Outreach** — find the right contacts, draft warm messages
+- **Application Tracker** — status overview across all active opportunities
+- **Follow-up Cadence** — surface stale applications, suggest next steps
+- **Rejection Patterns** — analyse what's not working and sharpen targeting
+- **Live Apply Assist** — fill application forms (always stops before Submit)
+
+## 14 Skill Modes
+
+`oferta` · `ofertas` · `pipeline` · `pdf` · `latex` · `scan` · `batch` ·
+`contacto` · `deep` · `interview-prep` · `training` · `project` · `tracker` ·
+`apply` · `patterns` · `followup`
+
+## Multi-Language Support
+
+Runs in English (default), German/DACH, French/Francophone, and Japanese —
+with market-specific vocabulary for each region.
+
+## Human-in-the-Loop
+
+Career-ops **never submits an application without explicit user approval.**
+The agent evaluates, drafts, and prepares — the human always makes the final
+call.
+
+## Example Usage
+
+```
+# Evaluate a job posting
+/career-ops <job-url>
+
+# Scan portals for new openings
+/career-ops scan
+
+# Generate a tailored CV
+/career-ops pdf
+
+# See all commands
+/career-ops
+```
+
+## Links
+
+- Repository: https://github.com/santifer/career-ops
+- Author: https://santifer.io

--- a/agents/santifer__career-ops/metadata.json
+++ b/agents/santifer__career-ops/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "career-ops",
+  "author": "santifer",
+  "description": "AI-powered job search pipeline: score offers A–G, generate tailored CVs, scan 45+ portals, track applications, prep interviews. 14 skill modes, multi-language (EN/DE/FR/JA).",
+  "repository": "https://github.com/santifer/career-ops",
+  "path": "",
+  "version": "1.0.0",
+  "category": "productivity",
+  "tags": ["job-search", "career", "cv-generation", "claude-code", "automation", "interview-prep", "resume", "recruiting", "ai-agent", "job-tracker"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **career-ops** by [@santifer](https://github.com/santifer) to the Open GAP registry.

**Repo:** https://github.com/santifer/career-ops
**Category:** productivity
**Tags:** job-search, career, cv-generation, claude-code, automation, interview-prep, resume, recruiting, ai-agent, job-tracker

career-ops is an AI-powered job search pipeline built on Claude Code — 14 skill modes covering offer evaluation (A–G scoring), ATS-optimised CV generation, zero-cost portal scanning, batch processing, interview prep, and more. Multi-language (EN/DE/FR/JA). Human-in-the-loop always required before any application is submitted.

A PR proposing `agent.yaml` + `SOUL.md` to the upstream repo is open at: https://github.com/santifer/career-ops/pull/758

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.