### PR TITLE
Add SWE-agent/mini-swe-agent

### DIFF
--- a/agents/SWE-agent__mini-swe-agent/README.md
+++ b/agents/SWE-agent__mini-swe-agent/README.md
@@ -1,0 +1,65 @@
+# mini-swe-agent
+
+**The minimal AI software engineering agent** — ~100 lines of Python, no custom tools, just bash.
+
+Built by the Princeton & Stanford team behind [SWE-bench](https://swebench.com) and [SWE-agent](https://swe-agent.com),
+`mini-swe-agent` asks: *what if our agent was 100x simpler, and still worked nearly as well?*
+
+## What it does
+
+`mini` resolves GitHub issues, writes and edits code, and assists with any command-line task
+by iteratively reasoning and executing bash commands. It scored **>74% on SWE-bench Verified**
+with Gemini 3 Pro — rivalling far more complex agents.
+
+## Key capabilities
+
+- 🐚 **Bash-only** — no tool-calling API needed; works with literally any LLM
+- 📦 **Multi-environment** — local, Docker/Podman, Singularity, bubblewrap, contree
+- 🤖 **Any model** — powered by [litellm](https://github.com/BerriAI/litellm); OpenAI, Anthropic, Gemini, open-source via openrouter
+- 📈 **Linear trajectory** — every step appends to history; great for debugging & fine-tuning
+- ⚡ **Fast startup** — lighter than Claude Code, zero config required to start
+
+## Quick start
+
+```bash
+pip install mini-swe-agent
+mini  # launches the interactive CLI
+```
+
+Or run without installing:
+
+```bash
+pip install uv && uvx mini-swe-agent
+```
+
+## Example usage
+
+```python
+from minisweagent.agents.default import DefaultAgent
+from minisweagent.models.litellm_model import LitellmModel
+from minisweagent.environments.local import LocalEnvironment
+
+agent = DefaultAgent(
+    LitellmModel(model_name="claude-sonnet-4-5"),
+    LocalEnvironment(),
+)
+agent.run("Fix the failing tests in src/utils.py")
+```
+
+## Benchmarks
+
+| Model | SWE-bench Verified |
+|---|---|
+| Gemini 3 Pro | >74% |
+| GPT-5 / Sonnet 4 (random switch) | boosted performance |
+
+## Adopted by
+
+Meta, NVIDIA, Essential AI, IBM, Nebius, Anyscale, Princeton University, Stanford University, and many more.
+
+## Links
+
+- 📚 [Documentation](https://mini-swe-agent.com/latest/)
+- 🐙 [GitHub](https://github.com/SWE-agent/mini-swe-agent)
+- 📦 [PyPI](https://pypi.org/project/mini-swe-agent/)
+- 🏆 [SWE-bench Leaderboard](https://www.swebench.com/)

--- a/agents/SWE-agent__mini-swe-agent/metadata.json
+++ b/agents/SWE-agent__mini-swe-agent/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "mini-swe-agent",
+  "author": "SWE-agent",
+  "description": "A radically minimal AI software engineering agent (~100 lines) that resolves GitHub issues and CLI tasks via bash. >74% on SWE-bench Verified. No custom tools — just the shell.",
+  "repository": "https://github.com/SWE-agent/mini-swe-agent",
+  "path": "",
+  "version": "2.0.0",
+  "category": "developer-tools",
+  "tags": ["software-engineering", "swe-bench", "bash", "code-agent", "github-issues", "minimal", "litellm", "docker", "python", "autonomous"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **mini-swe-agent** by SWE-agent to the registry.

Repo: https://github.com/SWE-agent/mini-swe-agent — a radically minimal AI software engineering agent (~100 lines of Python) that resolves GitHub issues and CLI tasks via bash. Scored >74% on SWE-bench Verified. No custom tools, just the shell. MIT licensed. 4700+ stars.

**What's included:**
- `agents/SWE-agent__mini-swe-agent/metadata.json` — category: `developer-tools`, tags: software-engineering, swe-bench, bash, code-agent, minimal, and more
- `agents/SWE-agent__mini-swe-agent/README.md` — full description with capabilities, benchmarks, quick-start, and examples

A GAP PR (`agent.yaml` + `SOUL.md`) has been opened upstream at https://github.com/SWE-agent/mini-swe-agent/pull/845. The registry CI check for those files will pass once that PR is merged.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.