### PR TITLE
Add algorand-devrel/algorand-agent-skills

### DIFF
--- a/agents/algorand-devrel__algorand-agent-skills/README.md
+++ b/agents/algorand-devrel__algorand-agent-skills/README.md
@@ -1,0 +1,43 @@
+# Algorand Agent Skills
+
+A canonical collection of agent skills and configurations for **AI-assisted Algorand blockchain development**. Drop these skills into any AI coding assistant — Claude Code, OpenCode, Cursor, or GitHub Copilot — and it gains deep, accurate knowledge of the Algorand ecosystem.
+
+## What it does
+
+The agent teaches AI assistants to build correct, idiomatic Algorand applications by loading only the reference files they need (progressive disclosure):
+
+| Skill | Purpose |
+|---|---|
+| `algorand-core` | AVM mental model — stack machine, `uint64`/`bytes` types, opcode budgets, resource limits |
+| `algorand-project-setup` | AlgoKit project init, CLI commands, examples |
+| `algorand-typescript` | Full TypeScript lifecycle: PuyaTs syntax, testing, deployment, AlgoKit Utils, ARC standards |
+| `algorand-python` | Full Python lifecycle: PuyaPy syntax, testing, deployment, AlgoKit Utils, ARC standards |
+| `algorand-frontend` | React dApps with `@txnlab/use-wallet-react` and the signer-handoff pattern |
+| `algokit-utils-ts` / `algokit-utils-py` | Typed client setup, payments, assets, contract interaction |
+| `algorand-x402-typescript` | TypeScript x402 HTTP-native payments: clients, servers, facilitators, paywalls |
+| `algorand-x402-python` | Python x402 HTTP-native payments: clients, servers, facilitators, Bazaar |
+
+## Key capabilities
+
+- Prevents AVM mistakes caused by treating Algorand like EVM or writing TEAL by hand
+- Routes to canonical AlgoKit CLI build/test/deploy pipeline
+- Integrates MCP tools for live documentation search (`kapa`) and code examples (`github`)
+- Covers x402, the HTTP-native payment protocol built on Algorand
+
+## Example usage
+
+```bash
+# In an AlgoKit project, add the skills:
+cp -r algorand-agent-skills/skills ./
+cp algorand-agent-skills/setups/AGENTS.md ./
+cp algorand-agent-skills/setups/claude-code/.mcp.json ./
+cp algorand-agent-skills/setups/claude-code/CLAUDE.md ./
+
+# Then in Claude Code:
+# "Build a smart contract that holds ALGO and releases on condition"
+# → agent loads algorand-core, then algorand-typescript, searches docs, writes PuyaTs
+```
+
+## Supported runtimes
+
+Claude Code, OpenCode, Cursor, GitHub Copilot — setup guides in `setups/`.

--- a/agents/algorand-devrel__algorand-agent-skills/metadata.json
+++ b/agents/algorand-devrel__algorand-agent-skills/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "algorand-agent-skills",
+  "author": "algorand-devrel",
+  "description": "Canonical agent skills for AI-assisted Algorand development: smart contracts, AVM patterns, AlgoKit tooling, TypeScript/Python lifecycle, React dApps, and x402 payments.",
+  "repository": "https://github.com/computer-agent/algorand-agent-skills",
+  "path": "",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["algorand", "blockchain", "smart-contracts", "algokit", "typescript", "python", "web3", "x402", "claude-code", "opencode"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **algorand-agent-skills** by `algorand-devrel` to the Open GAP registry.

This is a canonical collection of AI agent skills for Algorand blockchain development — smart contracts (PuyaTs/PuyaPy), AVM mental model, AlgoKit tooling, React dApp frontends, AlgoKit Utils, and x402 HTTP-native payment flows. It already ships a structured skill system with progressive disclosure, making it a natural fit for the GAP protocol.

**Repo:** https://github.com/algorand-devrel/algorand-agent-skills
**GAP files:** `agent.yaml` + `SOUL.md` are present and validated ✓
**Category:** developer-tools
**Tags:** algorand, blockchain, smart-contracts, algokit, typescript, python, web3, x402, claude-code, opencode

> Note: `repository` currently points at the bot's fork (where the GAP files have been pushed) while [the upstream PR](https://github.com/algorand-devrel/algorand-agent-skills/pull/10) is under review. Once the maintainer merges the GAP files, this entry can be updated to point at the canonical repo. Happy to update in a follow-up commit.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.