### PR TITLE
Add simonw/llm

### DIFF
--- a/agents/simonw__llm/README.md
+++ b/agents/simonw__llm/README.md
@@ -1,0 +1,50 @@
+# LLM
+
+**LLM** is a CLI tool and Python library by [Simon Willison](https://github.com/simonw) for running prompts, chatting, and working with Large Language Models — all from a single, consistent interface.
+
+## What it does
+
+- **Run prompts** from the command-line against any supported model:
+  ```bash
+  llm "Explain the CAP theorem in plain English"
+  llm -m claude-4-opus "Review this PR" < diff.txt
+  ```
+- **Multi-turn chat** sessions:
+  ```bash
+  llm chat -m gemini-2.0-flash
+  ```
+- **Tool use** — register Python functions and let the model call them during inference.
+- **Structured output** — extract typed JSON with `llm -s "..." --schema '...'`.
+- **Embeddings** — generate and store vectors for semantic search.
+- **Templates** — save named system prompts: `llm -t my-template`.
+- **Plugin system** — extend model support: `llm install llm-anthropic`.
+- **Automatic logging** — every prompt/response stored in SQLite, queryable with `llm logs`.
+
+## Key capabilities
+
+| Skill | Command |
+|-------|---------|
+| One-shot prompt | `llm "..."` |
+| Interactive chat | `llm chat` |
+| Embeddings | `llm embed` |
+| Log viewer | `llm logs` |
+| Plugin management | `llm install` |
+| Key management | `llm keys set <provider>` |
+
+## Models supported
+
+Works with OpenAI (gpt-4o, gpt-4o-mini), Anthropic Claude (via plugin), Google Gemini (via plugin), local models via Ollama, llama.cpp, MLX, and dozens more through the plugin ecosystem.
+
+## Install
+
+```bash
+pip install llm
+# or
+brew install llm
+```
+
+## Links
+
+- 📦 PyPI: https://pypi.org/project/llm/
+- 📖 Docs: https://llm.datasette.io
+- 🐙 GitHub: https://github.com/simonw/llm

--- a/agents/simonw__llm/metadata.json
+++ b/agents/simonw__llm/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "llm",
+  "author": "simonw",
+  "description": "CLI tool and Python library to run prompts, chat, embed, use tools and extract schemas across OpenAI, Anthropic, Gemini, Ollama and dozens more LLMs.",
+  "repository": "https://github.com/simonw/llm",
+  "version": "0.32.0",
+  "category": "developer-tools",
+  "tags": ["cli", "llm", "openai", "anthropic", "gemini", "ollama", "embeddings", "tools", "python"],
+  "license": "Apache-2.0",
+  "model": "openai:gpt-4o-mini",
+  "adapters": ["system-prompt", "claude-code"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **llm** by [@simonw](https://github.com/simonw) to the registry.

- **Repo:** https://github.com/simonw/llm
- **Category:** `developer-tools`
- **Tags:** `cli`, `llm`, `openai`, `anthropic`, `gemini`, `ollama`, `embeddings`, `tools`, `python`
- **Description:** CLI tool and Python library to run prompts, chat, embed, use tools and extract schemas across OpenAI, Anthropic, Gemini, Ollama and dozens more LLMs.
- **License:** Apache-2.0
- **Stars:** ~12,000

A `agent.yaml` + `SOUL.md` PR has been proposed to the source repo at https://github.com/simonw/llm/pull/1463 — the registry CI will be able to verify once those files land on the default branch.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.