### PR TITLE
Add mmlong818/skillforge

### DIFF
--- a/agents/mmlong818__skillforge/README.md
+++ b/agents/mmlong818__skillforge/README.md
@@ -1,0 +1,55 @@
+# SkillForge
+
+**SkillForge** is an open-source web application that generates production-grade
+AI Agent Skill packages through a structured 7-step pipeline, strictly aligned
+with the Anthropic Agent Skills specification.
+
+## What It Does
+
+Give SkillForge a skill name and description and it will:
+
+1. **Analyse requirements** — identifies functional boundaries, usage scenarios,
+   and — most critically — the *knowledge gap* (what the model doesn't already
+   know and therefore needs in the SKILL.md).
+2. **Decide architecture** — selects the right structure pattern, freedom level,
+   and plans all supporting resource files.
+3. **Craft metadata** — generates and scores three candidate `description` values;
+   picks the one with the best trigger precision and information density.
+4. **Generate SKILL.md body** — 150–450 lines with overview, workflow, rules,
+   ❌/✅ anti-pattern examples, edge cases, and a validation checklist.
+5. **Quality audit** — scores the draft on 10 dimensions (1–10 each); fixes
+   anything below 8.
+6. **Generate resource files** — produces all `scripts/`, `references/`, and
+   `templates/` files planned in Step 2. No `...` or `TODO` placeholders.
+7. **Write usage docs** — installation steps, ≥5 natural-language trigger
+   examples, iteration suggestions, and a final checklist.
+
+It also **repairs existing Skills** via a 3-step diagnose → rewrite → audit flow.
+
+## Key Features
+
+- Real-time streaming output for every pipeline step
+- `%%SKILL_BEGIN%%` / `%%SKILL_END%%` marker extraction — no truncation
+- ZIP download of the complete skill package (SKILL.md + supporting files)
+- Cancel running tasks, retry failed steps, delete history
+- Supports Claude CLI, Anthropic API, and any OpenAI-compatible backend
+- Full-stack TypeScript: React 19 + Tailwind CSS 4 + Express + tRPC + MySQL
+
+## Example Usage
+
+> "Generate a skill for scraping product prices from e-commerce pages."
+
+> "Fix my existing git-rebase skill — it keeps getting triggered for the wrong tasks."
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 19, Tailwind CSS 4, shadcn/ui |
+| Backend | Express 4, tRPC 11 |
+| Database | MySQL / TiDB (Drizzle ORM) |
+| LLM | Claude CLI / Anthropic API / OpenAI-compatible |
+
+## Repository
+
+https://github.com/mmlong818/skillforge

--- a/agents/mmlong818__skillforge/metadata.json
+++ b/agents/mmlong818__skillforge/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "skillforge",
+  "author": "mmlong818",
+  "description": "Generates production-grade AI Agent Skill packages via a 7-step pipeline: analysis, architecture, metadata, SKILL.md body, quality audit, resource files, and usage docs.",
+  "repository": "https://github.com/mmlong818/skillforge",
+  "version": "1.4.0",
+  "category": "developer-tools",
+  "tags": ["skill-generator", "agent-skills", "prompt-engineering", "ai-agents", "claude", "anthropic", "pipeline", "code-generation"],
+  "license": "CC-BY-NC-SA-4.0",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **SkillForge** by [mmlong818](https://github.com/mmlong818) to the registry.

Repo: https://github.com/mmlong818/skillforge — SkillForge is a full-stack web application and AI agent that generates production-grade Agent Skill packages through a structured multi-step pipeline, strictly aligned to the Anthropic Agent Skills specification. It supports Claude CLI, Anthropic API, and any OpenAI-compatible backend.

**GAP files:** `agent.yaml` + `SOUL.md` are proposed via [PR #5](https://github.com/mmlong818/skillforge/pull/5) on the target repo (pending maintainer acceptance). Both files exist on the `gitagent-protocol` branch of the fork.

**Category:** `developer-tools`
**Tags:** `skill-generator`, `agent-skills`, `claude`, `prompt-engineering`, `ai-agents`, `typescript`, `webapp`, `anthropic`, `quality-audit`, `code-generation`

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.