### PR TITLE
Add Cranot/deep-research

### DIFF
--- a/agents/Cranot__deep-research/README.md
+++ b/agents/Cranot__deep-research/README.md
@@ -1,0 +1,58 @@
+# Deep Research
+
+**Fractal exploration of any question through recursive AI agents.**
+
+Deep Research is a multi-agent system that takes any question and transforms it into a comprehensive, synthesized report by recursively decomposing it. An orchestrator agent breaks the question into angles, each angle spawns sub-agents to investigate further, and everything synthesizes back up the tree into one authoritative answer.
+
+## What it does
+
+- **Recursive decomposition** — complex questions are broken into sub-questions automatically, to any depth
+- **Parallel exploration** — all sub-agents run concurrently for fast results
+- **Multi-model ensemble support** — use Claude, Gemini, Kimi, Grok, or Azure OpenAI at different tree levels
+- **Four research strategies**: recursive, Socratic, perspective expansion, and web-grounded
+- **Persistent checkpoints** — resume interrupted research from where it left off
+- **Typed knowledge graphs** — every finding carries epistemic state (Unknown → Explored → Validated → Synthesized)
+
+## Example usage
+
+```bash
+# Basic research (Claude opus orchestrator + haiku researchers)
+deep-research research "What makes startups successful?"
+
+# Socratic mode — improve the question first
+deep-research socratic "How do I become more productive?"
+
+# Perspective expansion
+deep-research perspectives "What makes good leadership?"
+
+# Grounded research with web search
+deep-research research --strategy grounded_research "Current state of AI agents"
+
+# Legacy bash (still works)
+./deep-research.sh -m opus -r haiku -d 2 "Why do smart people make bad decisions?"
+```
+
+## Output
+
+Reports save to `reports/YYYY-MM-DD-question-slug/SYNTHESIS.md` with individual agent outputs in `agents/`.
+
+## Models supported
+
+| Provider | Models |
+|---|---|
+| Claude | opus, sonnet, haiku |
+| Gemini | flash, pro |
+| OpenRouter | grok, grok-3, grok-4 |
+| Kimi | kimi (free, best merger) |
+| Azure OpenAI | gpt5-mini |
+
+## Skills
+
+| Skill | Description |
+|---|---|
+| `recursive_research` | Decompose → spawn parallel researchers → synthesize |
+| `socratic` | Challenge assumptions, surface better questions |
+| `perspective_expander` | Multi-angle analysis with blind spot detection |
+| `grounded_research` | Web-verified, fact-checked answers |
+
+Created by [Dimitris Mitsos](https://github.com/Cranot) & [AgentsKB.com](https://agentskb.com). MIT licensed.

--- a/agents/Cranot__deep-research/metadata.json
+++ b/agents/Cranot__deep-research/metadata.json
@@ -1,0 +1,28 @@
+{
+  "name": "deep-research",
+  "author": "Cranot",
+  "description": "Fractal research agent: decomposes any question into recursive sub-questions, explores all angles in parallel with multiple LLMs, and synthesizes back into a comprehensive report.",
+  "repository": "https://github.com/Cranot/deep-research",
+  "version": "1.0.0",
+  "category": "research",
+  "tags": [
+    "multi-agent",
+    "recursive",
+    "research",
+    "synthesis",
+    "claude",
+    "gemini",
+    "web-search",
+    "knowledge-graph",
+    "parallel-agents",
+    "fractal"
+  ],
+  "license": "MIT",
+  "model": "claude-opus-4-5",
+  "adapters": [
+    "claude-code",
+    "system-prompt"
+  ],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **deep-research** by [Cranot](https://github.com/Cranot) to the registry.

**Repo:** https://github.com/Cranot/deep-research
**Category:** research
**Tags:** multi-agent, recursive, research, synthesis, claude, gemini, web-search, knowledge-graph, parallel-agents, fractal

**What it does:** Fractal research agent that decomposes any question into a recursive tree of sub-questions, explores all angles in parallel across multiple LLM providers (Claude, Gemini, Kimi, Grok), then synthesizes findings back up into one comprehensive report. Four strategies: recursive, Socratic, perspective expansion, and web-grounded.

**GAP files:** A PR adding `agent.yaml` + `SOUL.md` to the upstream repo is open at https://github.com/Cranot/deep-research/pull/1 and pending maintainer review. The registry CI validation will pass once that PR is merged to main. Re-running CI after merge will confirm.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.