### PR TITLE
Add coleam00/claude-memory-compiler

### DIFF
--- a/agents/coleam00__claude-memory-compiler/README.md
+++ b/agents/coleam00__claude-memory-compiler/README.md
@@ -1,0 +1,55 @@
+# Claude Memory Compiler
+
+An autonomous background agent that turns your Claude Code conversations into a
+growing, searchable personal knowledge base — automatically.
+
+## What It Does
+
+Inspired by [Andrej Karpathy's LLM Knowledge Base](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f),
+this agent installs three Claude Code lifecycle hooks that run silently in the
+background:
+
+| Hook | What it does |
+|---|---|
+| `SessionEnd` | Captures the transcript and spawns a background flush |
+| `PreCompact` | Safety net — also flushes before Claude compacts context |
+| `SessionStart` | Injects the compiled knowledge index into the next session |
+
+## Core Skills
+
+- **memory-flush** — Calls the Claude Agent SDK to extract decisions, lessons,
+  and patterns from a session transcript and appends them to a dated daily log.
+- **knowledge-compile** — Reads daily logs and compiles them into structured,
+  cross-referenced Markdown articles (`concepts/`, `connections/`, `qa/`).
+- **knowledge-query** — Answers natural-language questions by reading the master
+  index first, then pulling relevant articles — no vector database needed.
+- **knowledge-lint** — Runs seven health checks (broken links, orphans,
+  contradictions, staleness) against the compiled knowledge base.
+
+## Why No RAG?
+
+At personal scale (50–500 articles), an LLM reading a structured `index.md`
+outperforms cosine similarity. RAG becomes necessary only when the index itself
+exceeds the context window (~2 000+ articles).
+
+## Quick Start
+
+```
+Tell Claude Code:
+"Clone https://github.com/coleam00/claude-memory-compiler into this project
+and set up the hooks so my conversations compile into a knowledge base.
+Read AGENTS.md for the full technical reference."
+```
+
+## Key Commands
+
+```bash
+uv run python scripts/compile.py          # compile new daily logs
+uv run python scripts/query.py "question" # ask the knowledge base
+uv run python scripts/lint.py             # run health checks
+```
+
+## Links
+
+- **Repository:** https://github.com/coleam00/claude-memory-compiler
+- **Technical reference:** `AGENTS.md` in the repo

--- a/agents/coleam00__claude-memory-compiler/metadata.json
+++ b/agents/coleam00__claude-memory-compiler/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-memory-compiler",
+  "author": "coleam00",
+  "description": "Autonomous Claude Code agent that captures session transcripts via hooks, extracts decisions and lessons using Claude Agent SDK, and compiles them into a cross-referenced knowledge base.",
+  "repository": "https://github.com/coleam00/claude-memory-compiler",
+  "path": "",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["memory", "knowledge-base", "claude-code", "hooks", "productivity", "personal-knowledge", "agent-sdk", "automation"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-6",
+  "adapters": ["claude-code"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **claude-memory-compiler** by [@coleam00](https://github.com/coleam00) to the Open GAP registry.

Repo: https://github.com/coleam00/claude-memory-compiler — a Claude Code agent that automatically compiles conversation transcripts into a cross-referenced personal knowledge base using session hooks, flush/compile/query/lint scripts, and the Claude Agent SDK.

**Entry details:**
- **Category:** productivity
- **Tags:** knowledge-base, memory, claude-code, hooks, personal, markdown, compiler, productivity
- **Model:** claude-sonnet-4-5-20250929
- **Adapters:** claude-code, system-prompt
- **License:** MIT

A companion PR ([coleam00/claude-memory-compiler#22](https://github.com/coleam00/claude-memory-compiler/pull/22)) adds `agent.yaml` + `SOUL.md` to the target repo. The registry CI check will pass once that PR is merged onto the default branch.

---

⭐ If the GAP standard looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.