### PR TITLE
Add yogirk/agent-council

### DIFF
--- a/agents/yogirk__agent-council/README.md
+++ b/agents/yogirk__agent-council/README.md
@@ -1,0 +1,68 @@
+# Agent Council
+
+**Convene a panel of CLI-based AI agents to deliberate on your hardest engineering questions.**
+
+Agent Council orchestrates Claude Code, Codex CLI, and Gemini CLI through a structured
+three-stage deliberation — independent opinions, peer review, and chairman synthesis — then
+delivers a verdict with consensus mapping, divergence analysis, and a confidence score.
+
+## What makes it different
+
+Every existing LLM council is API-based (pass text, get text back). Agent Council is
+different: council members are **CLI agents with tool access**. They can grep your codebase,
+read migration files, and run `git log` before opining. Opinions are grounded in your
+actual project, not abstract text generation.
+
+You're also tapping into **subscriptions you already have** — no new API tokens required.
+
+## Key Capabilities
+
+- **`/council "question"`** — Dispatch all agents in parallel, collect independent opinions, synthesise as chairman
+- **`/council --with-review`** — Add a Stage 2 peer-review round before synthesis
+- **`/council --quick`** — Skip peer review for fast turnaround
+- **`/council-list`** — List all past deliberation sessions
+- **`/council-replay <session>`** — Replay a past session in the terminal
+- **`/council-revisit <session>`** — Re-run deliberation with current project context ("living decisions")
+- **`/council-outcome <session> "result"`** — Record what actually happened to close the loop
+- **`/council-nudge <session> --agent codex --correction "..."`** — Dispatch a targeted Stage 4 correction to a single agent
+
+## Example
+
+```
+/council "Should we use Postgres or DynamoDB for our event sourcing system?"
+```
+
+```
+Stage 1 complete: 3/3 successful opinions
+
+--- CHAIRMAN SYNTHESIS (claude) ---
+
+Consensus: All agents agree — Postgres is the right choice given strong
+consistency requirements and team SQL experience.
+
+Divergence: Claude emphasises ACID guarantees. Codex flags a 10TB scaling
+ceiling without sharding. Gemini suggests read replicas as a scaling bridge.
+
+Confidence: HIGH — Strong consensus across models.
+```
+
+## Installation
+
+```bash
+npx cliagent-council
+```
+
+Or manually:
+
+```bash
+git clone https://github.com/yogirk/agent-council.git
+cd agent-council && ./setup
+```
+
+**Requirements:** [Bun](https://bun.sh) + at least 2 of: Claude Code, Codex CLI, Gemini CLI.
+
+## GitAgent Protocol
+
+This agent ships with `agent.yaml` + `SOUL.md` at the repo root, making it fully
+[GAP-compliant](https://gitagent.sh). Run it on any compatible runtime or list it
+in the [Open GAP registry](https://registry.gitagent.sh).

--- a/agents/yogirk__agent-council/metadata.json
+++ b/agents/yogirk__agent-council/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-council",
+  "author": "yogirk",
+  "description": "Convenes a panel of CLI AI agents (Claude, Codex, Gemini) to deliberate on engineering questions via structured multi-stage discussion and chairman synthesis.",
+  "repository": "https://github.com/yogirk/agent-council",
+  "path": "",
+  "version": "0.3.3",
+  "category": "developer-tools",
+  "tags": ["multi-agent", "deliberation", "claude-code", "codex", "gemini-cli", "engineering-decisions", "code-review", "architecture"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **Agent Council** by [@yogirk](https://github.com/yogirk) to the registry.

Repo: https://github.com/yogirk/agent-council — a multi-agent CLI deliberation tool that convenes Claude Code, Codex CLI, and Gemini CLI to deliberate on engineering questions through structured three-stage discussion (independent opinions → peer review → chairman synthesis).

**Why it's a great fit for the registry:**
- Actively maintained, MIT licensed, v0.3.3
- Genuinely novel approach: council members are CLI agents with tool access (grep, git log), not API text passthrough
- Cross-compatible with Claude Code, Codex CLI, Gemini CLI
- A GAP PR adding `agent.yaml` + `SOUL.md` is open at https://github.com/yogirk/agent-council/pull/11

**Note on CI:** The registry CI checks for `agent.yaml` + `SOUL.md` on the target repo's default branch. Those files are proposed via PR #11 on the target repo — once merged (or if the maintainer commits them directly), this PR's CI will pass clean. The files are already live on the `gitagent-protocol` branch.

Category: `developer-tools` · Tags: multi-agent, deliberation, claude-code, codex, gemini-cli, engineering-decisions, code-review, architecture

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.