### PR TITLE
Add context-machine-lab/sleepless-agent

### DIFF
--- a/agents/context-machine-lab__sleepless-agent/README.md
+++ b/agents/context-machine-lab__sleepless-agent/README.md
@@ -1,0 +1,64 @@
+# Sleepless Agent
+
+**A 24/7 AgentOS that keeps working while you sleep — powered by Claude Code.**
+
+> Repo: https://github.com/context-machine-lab/sleepless-agent
+
+## What it does
+
+Sleepless Agent is a persistent background daemon that transforms your Claude Code
+Pro subscription into a continuously-running AI development assistant. Instead of
+leaving your allocation idle overnight, it picks up tasks and executes them
+autonomously, surfacing the results as GitHub PRs for your morning review.
+
+## Key capabilities
+
+| Capability | Description |
+|---|---|
+| **Slack + CLI interface** | Submit tasks via `/think` in Slack or the `sle` CLI — no browser needed |
+| **Multi-agent pipeline** | Every task flows through a Planner → Worker → Evaluator chain |
+| **Isolated workspaces** | Each task runs in its own directory; parallel tasks never collide |
+| **Auto task generation** | During idle windows the agent brainstorms and self-assigns new work |
+| **Budget-aware scheduling** | Separate day/night Claude usage thresholds prevent quota exhaustion |
+| **Git-native output** | Completed work lands on a feature branch with an auto-opened PR |
+
+## Example usage
+
+```bash
+# Install
+pip install sleepless-agent
+
+# Start the 24/7 daemon
+sle daemon
+
+# Submit a task (Slack or CLI)
+sle add "Refactor the auth module to use JWT"
+
+# Check status
+sle check
+
+# Read a result
+sle report 42
+```
+
+## Architecture
+
+```
+Slack / CLI  →  Task Queue (SQLite)  →  Smart Scheduler
+                                              │
+                              ┌───────────────┴───────────────┐
+                          Planner                          Auto-Generator
+                              │
+                           Worker  ←── isolated workspace
+                              │
+                          Evaluator  →  Git commit  →  PR
+```
+
+## Model
+
+Uses `claude-sonnet-4-5-20250929` via the Claude Code Python Agent SDK with a
+30-turn worker budget and a 1800-second per-task timeout.
+
+## License
+
+MIT — see [LICENSE](https://github.com/context-machine-lab/sleepless-agent/blob/main/LICENSE)

--- a/agents/context-machine-lab__sleepless-agent/metadata.json
+++ b/agents/context-machine-lab__sleepless-agent/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "sleepless-agent",
+  "author": "context-machine-lab",
+  "description": "24/7 AgentOS maximising Claude Code Pro usage: daemon accepts tasks via Slack/CLI, runs planner→worker→evaluator pipeline in isolated workspaces, auto-generates idle tasks, and commits results as PRs.",
+  "repository": "https://github.com/context-machine-lab/sleepless-agent",
+  "path": "",
+  "version": "0.1.2",
+  "category": "developer-tools",
+  "tags": ["claude-code", "automation", "daemon", "multi-agent", "slack", "git", "productivity", "agentOS", "scheduler", "workspace"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **sleepless-agent** by [context-machine-lab](https://github.com/context-machine-lab) to the Open GAP registry.

**Repo:** https://github.com/context-machine-lab/sleepless-agent
**What it does:** A 24/7 AgentOS daemon that accepts tasks via Slack or CLI, orchestrates a planner→worker→evaluator multi-agent pipeline in isolated workspaces, auto-generates exploratory tasks during idle periods, and surfaces results as GitHub PRs.
**Category:** `developer-tools`
**Tags:** `claude-code`, `automation`, `daemon`, `multi-agent`, `slack`, `git`, `productivity`, `agentOS`, `scheduler`, `workspace`
**Model:** `claude-sonnet-4-5-20250929`
**License:** MIT

A companion PR adding `agent.yaml` + `SOUL.md` to the upstream repo is open at https://github.com/context-machine-lab/sleepless-agent/pull/22. Once that merges, the registry CI `agent.yaml`/`SOUL.md` check will pass on the default branch.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.