### PR TITLE
Add berkcangumusisik/repo-seatbelt

### DIFF
--- a/agents/berkcangumusisik__repo-seatbelt/README.md
+++ b/agents/berkcangumusisik__repo-seatbelt/README.md
@@ -1,0 +1,35 @@
+# repo-seatbelt
+
+A four-layer safety system that stands between AI coding agents and the irreversible parts of your repository.
+
+## What it does
+
+**repo-seatbelt** scans your project, computes an AI Safety Score (0–100), and generates safety rule files for 8 AI tools simultaneously — Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Aider, Cline, and Zed. It also ships a live MCP guardrail server, a pre-commit hook, and a GitHub Action CI gate.
+
+### Four layers of protection
+
+| Layer | What it does |
+|-------|-------------|
+| **Static rules** | Generates `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, `CONVENTIONS.md`, `.clinerules`, `.rules` so agents know your boundaries on session start |
+| **Runtime MCP guardrail** | A live MCP server agents call at decision-time: `check_file_access`, `check_command`, `list_protections` |
+| **Pre-commit hook** | Blocks high-risk commits before they leave the developer's machine |
+| **CI gate** | GitHub Action that posts an AI Safety Score on every PR and fails on high-risk diffs |
+
+## Quick start
+
+```bash
+npx repo-seatbelt init          # interactive setup
+npx repo-seatbelt scan          # AI Safety Score + risk report
+npx repo-seatbelt mcp           # start the MCP guardrail server
+npx repo-seatbelt install-hooks # add pre-commit protection
+npx repo-seatbelt ci            # add GitHub Action gate
+```
+
+## Supported tools
+
+Claude Code · Cursor · Codex / ChatGPT · Gemini CLI · Windsurf · Aider · Cline · Zed AI
+
+## Links
+
+- Repository: https://github.com/berkcangumusisik/repo-seatbelt
+- npm: https://www.npmjs.com/package/repo-seatbelt

--- a/agents/berkcangumusisik__repo-seatbelt/metadata.json
+++ b/agents/berkcangumusisik__repo-seatbelt/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "repo-seatbelt",
+  "author": "berkcangumusisik",
+  "description": "A four-layer AI coding agent safety system: generates rule files for 8 tools, MCP runtime guardrail, pre-commit hook, and CI gate with AI Safety Score.",
+  "repository": "https://github.com/berkcangumusisik/repo-seatbelt",
+  "path": "",
+  "version": "1.1.0",
+  "category": "security",
+  "tags": ["ai-safety", "guardrails", "mcp", "claude-code", "cursor", "pre-commit", "github-actions", "developer-tools", "ai-agents", "security"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **repo-seatbelt** by @berkcangumusisik to the Open GAP registry.

**What repo-seatbelt does:** A four-layer AI coding agent safety system — generates safety rule files for 8 AI tools (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Aider, Cline, Zed), exposes a live MCP runtime guardrail server, ships a pre-commit hook, and a GitHub Action CI gate with an AI Safety Score. Category: `security`.

**Repository:** https://github.com/berkcangumusisik/repo-seatbelt

**Note on CI:** The `agent.yaml` + `SOUL.md` files are being added to the target repo via a companion PR ([berkcangumusisik/repo-seatbelt#3](https://github.com/berkcangumusisik/repo-seatbelt/pull/3)). Once that PR is merged, the registry CI clone check will pass. The metadata and README in this PR are already valid.

**Tags:** `ai-safety`, `guardrails`, `mcp`, `claude-code`, `cursor`, `pre-commit`, `github-actions`, `developer-tools`, `ai-agents`, `security`

---

If GAP looks useful to you, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.