### PR TITLE
Add gtapps/claude-code-hermit

### DIFF
--- a/agents/gtapps__claude-code-hermit/README.md
+++ b/agents/gtapps__claude-code-hermit/README.md
@@ -1,0 +1,61 @@
+# claude-code-hermit
+
+> Turn Claude Code into a 24/7 personal AI assistant — self-learning, cost-aware, and operator-gated.
+
+**claude-code-hermit** is a Claude Code plugin that wires Claude's native scheduling, messaging channels, remote control, and memory system into a fully autonomous personal assistant you deploy on your own machine or in Docker. One Claude subscription powers multiple independent hermits — each with its own memory, budget, and routines.
+
+---
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/gtapps/claude-code-hermit
+```
+
+---
+
+## Install
+
+```bash
+cd /path/to/your/project
+claude plugin marketplace add gtapps/claude-code-hermit
+claude plugin install claude-code-hermit@claude-code-hermit --scope project
+
+# Boot and run the setup wizard
+claude /claude-code-hermit:hatch
+
+# Go always-on with Docker
+claude /claude-code-hermit:docker-setup
+```
+
+---
+
+## What It Can Do
+
+- **Always-on autonomy** — Runs on scheduled routines (morning brief, evening summary, heartbeat checks) via Claude Code's native `/loop` and `CronCreate`. Restarts automatically after sleep and network drops.
+- **Self-learning with operator control** — Reflects on session journals, identifies recurring patterns, and proposes improvements. Two subagents (`reflection-judge`, `proposal-triage`) vet candidates before they reach you. You approve via `/proposal-act accept <ID>` — nothing is applied without your say.
+- **Discord & Telegram channels** — Send commands and receive results via DM, exactly as if you were at the terminal. Powered by Claude Code's native Channels plugin.
+- **Cost transparency** — Every LLM call logged to `.claude/cost-log.jsonl`. Per-session totals in `.status.json`. Per-day rollup in `cost-summary.md`. Morning brief includes yesterday's spend. Soft `idle_budget` cap with a warning at 80%.
+- **Local & self-hosted** — Runs on bare tmux or Docker. Data stays on your hardware. No telemetry, no external dependencies beyond your Claude subscription.
+- **Hardened Docker baseline** — `cap_drop: ALL`, `no-new-privileges`, `pids_limit`. Opt-in `/docker-security` wizard adds LAN containment, DNS allowlist sidecar, and resource bounds.
+- **Observability skills** — `/hermit-brain` (open loops, fragile zones), `/hermit-evolution` (cost trends, behavioral shifts), `/hermit-health` (alert state, channel status, heartbeat).
+
+## Pre-built Domain Hermits
+
+Stack domain plugins on top of any hatched hermit:
+
+- **`dev-hermit`** — Safety layer for code-writing: push guard, branch discipline, gated PRs.
+- **`homeassistant-hermit`** — Home Assistant skills, automation builder, Python CLI.
+- **`fitness-hermit`** — Strava MCP wiring, activity deep-dives, weekly-load routines.
+
+## Architecture Highlights
+
+- **Voyager-style curriculum** — Raw session journals distill into compiled artifacts (`MEMORY.md` + domain files) that reload next session. The operator is editor-in-chief.
+- **Three-condition rule** — A pattern becomes a proposal only if it recurred, had a meaningful consequence, and admits a concrete actionable change. Noise is filtered before it reaches the inbox.
+- **`OPERATOR.md` as policy** — The `/hatch` wizard generates a personal rulebook capturing your priorities, constraints, and approval gates. The hermit reads it every session.
+
+## Links
+
+- [GitHub](https://github.com/gtapps/claude-code-hermit)
+- [Full Documentation](https://github.com/gtapps/claude-code-hermit/tree/main/plugins/claude-code-hermit/docs)
+- [Changelog](https://github.com/gtapps/claude-code-hermit/blob/main/plugins/claude-code-hermit/CHANGELOG.md)

--- a/agents/gtapps__claude-code-hermit/metadata.json
+++ b/agents/gtapps__claude-code-hermit/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-code-hermit",
+  "author": "gtapps",
+  "description": "A Claude Code plugin that turns Claude into a 24/7 always-on personal AI assistant with self-learning, cost tracking, Discord/Telegram channels, and operator-gated autonomy.",
+  "repository": "https://github.com/gtapps/claude-code-hermit",
+  "version": "1.1.6",
+  "category": "productivity",
+  "tags": ["claude-code", "autonomous-agent", "personal-assistant", "self-learning", "docker", "discord", "telegram", "cost-tracking", "operator-gated"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **claude-code-hermit** by [@gtapps](https://github.com/gtapps) to the Open GAP Registry.

**Repo:** https://github.com/gtapps/claude-code-hermit
**PR adding GAP files:** https://github.com/gtapps/claude-code-hermit/pull/196
**Category:** productivity
**Tags:** claude-code, autonomous-agent, personal-assistant, self-learning, docker, discord, telegram, cost-tracking, operator-gated

**What this agent does:** A Claude Code plugin that transforms Claude into a 24/7 always-on personal AI assistant. Hermit wires Claude's native scheduling (`/loop`, `CronCreate`), messaging channels (Discord, Telegram), remote control, cost tracking, and a self-learning proposal pipeline into a fully autonomous, operator-gated agent deployable to any machine or Docker container.

**What's included:**
- `agents/gtapps__claude-code-hermit/metadata.json` — valid registry entry (productivity category, MIT license, claude-code + system-prompt adapters)
- `agents/gtapps__claude-code-hermit/README.md` — full capability description with install instructions and architecture notes

**Note on CI:** The `agent.yaml` + `SOUL.md` files are being added to the target repo via the linked PR (#196 above). If CI checks for them on the default branch, they will be present once that PR merges. The files are already on the `gitagent-protocol` branch of the fork for immediate reference.

---

⭐ If GAP looks useful to you, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.