### PR TITLE
Add mrwadams/takedown-gpt

### DIFF
--- a/agents/mrwadams__takedown-gpt/README.md
+++ b/agents/mrwadams__takedown-gpt/README.md
@@ -1,0 +1,50 @@
+# TakedownGPT ⬇️🤖
+
+**TakedownGPT** is a LangChain-powered AI agent that automates the tedious
+research and drafting involved in filing domain takedown requests. Built by
+[Matt Adams](https://github.com/mrwadams), it combines WHOIS/RDAP lookups,
+live web search, and GPT-powered email drafting into a single autonomous workflow.
+
+## What it does
+
+Given a domain name and a takedown reason, the agent:
+
+1. **Identifies the domain registrar** — via WHOIS or RDAP lookup
+2. **Finds the abuse contact** — web-searches the registrar's takedown email address
+3. **Drafts a professional takedown email** — citing the stated reason and any additional context
+
+Supported takedown reasons include copyright infringement, trademark infringement,
+defamation/libel, privacy violations, malware/phishing, terms-of-service
+violations, personal safety concerns, and custom reasons.
+
+## Tools / Skills
+
+| Tool | Description |
+|------|-------------|
+| `get_registrar` | WHOIS lookup to identify the domain registrar |
+| `rdap_lookup` | RDAP protocol alternative for registrar queries |
+| `Search` | DuckDuckGo web search to find abuse contact emails |
+
+## Example usage
+
+```
+Domain: malicious-phishing-site.com
+Reason: Malware or phishing activities
+→ Agent finds registrar (e.g. GoDaddy), locates abuse@godaddy.com,
+  drafts a takedown request email ready to send.
+```
+
+## Model
+
+- Preferred: `openai:gpt-4o`
+- Fallback: `openai:gpt-3.5-turbo`
+
+## Human-in-the-loop
+
+The agent **drafts** the takedown email but does **not** submit it automatically.
+The human reviews and sends — `human_in_the_loop: destructive`.
+
+## Links
+
+- 📦 Repository: https://github.com/mrwadams/takedown-gpt
+- 🚀 Live demo: https://takedowngpt.streamlit.app

--- a/agents/mrwadams__takedown-gpt/metadata.json
+++ b/agents/mrwadams__takedown-gpt/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "takedown-gpt",
+  "author": "mrwadams",
+  "description": "LangChain agent that automates domain registrar lookups (WHOIS/RDAP) and drafts professional takedown request emails for malicious or infringing domains.",
+  "repository": "https://github.com/mrwadams/takedown-gpt",
+  "path": "",
+  "version": "1.0.0",
+  "category": "security",
+  "tags": ["domain-abuse", "takedown", "langchain", "whois", "rdap", "copyright", "phishing", "legal", "openai"],
+  "license": "MIT",
+  "model": "gpt-4o",
+  "adapters": ["system-prompt"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **TakedownGPT** by [@mrwadams](https://github.com/mrwadams) to the registry.

**Repo:** https://github.com/mrwadams/takedown-gpt  
**Category:** `security`  
**Tags:** domain-abuse, takedown, langchain, whois, rdap, copyright, phishing, legal, openai

TakedownGPT is a LangChain + OpenAI function-calling agent that automates domain registrar lookups (WHOIS/RDAP) and drafts professional takedown request emails for malicious or infringing domains. It's stateless, requires no persistent infrastructure, and the email draft is always reviewed by a human before sending (`human_in_the_loop: destructive`).

**⚠️ CI note:** The `agent.yaml` + `SOUL.md` files are currently on a pending PR to the target repo ([mrwadams/takedown-gpt#26](https://github.com/mrwadams/takedown-gpt/pull/26)). The registry CI check will pass once that PR is merged. Happy to merge this registry entry conditionally, or wait — whichever the maintainers prefer.

---

⭐ If the GitAgent Protocol looks like a useful standard, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover it.