### PR TITLE
Add tahreemrasul/math-wiz

### DIFF
--- a/agents/tahreemrasul__math-wiz/README.md
+++ b/agents/tahreemrasul__math-wiz/README.md
@@ -1,0 +1,47 @@
+# Math Wiz 🤖🧮
+
+**Math Wiz** is a LangChain-powered conversational agent that helps users work through arithmetic, numeric calculations, logic-based reasoning problems, and general knowledge questions. It runs as a Chainlit web chat application.
+
+## What it does
+
+Math Wiz uses a **ZERO_SHOT_REACT_DESCRIPTION** agent strategy with three specialised tools, routing each user query to the right tool automatically:
+
+| Tool | Purpose |
+|---|---|
+| **Calculator** | Evaluates pure numeric/arithmetic expressions via `LLMMathChain` |
+| **Reasoning Tool** | Solves logic and word problems step-by-step, presenting answers in bullet points |
+| **Wikipedia** | Looks up world events, dates, and factual information |
+
+## Example usage
+
+```
+User: What is 1234 * 5678?
+Math Wiz: [uses Calculator] → 7,006,652
+
+User: If a train travels at 60mph for 2.5 hours, how far does it go?
+Math Wiz: [uses Reasoning Tool] → 150 miles (shows working in bullets)
+
+User: When was calculus invented?
+Math Wiz: [uses Wikipedia] → 17th century, Newton and Leibniz...
+```
+
+## Getting started
+
+1. Clone the repo and install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Add your OpenAI API key to a `.env` file:
+   ```
+   OPENAI_API_KEY=your-key-here
+   ```
+3. Run:
+   ```bash
+   chainlit run chatbot.py -w --port 8000
+   ```
+
+## Links
+
+- **Repository:** https://github.com/tahreemrasul/math_app_langchain
+- **Live demo:** https://takedowngpt.streamlit.app *(see README)*
+- **Medium article:** https://medium.com/@tahreemrasul/how-to-build-your-own-chatbot-with-langchain-and-openai-f092822b6ba6

--- a/agents/tahreemrasul__math-wiz/metadata.json
+++ b/agents/tahreemrasul__math-wiz/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "math-wiz",
+  "author": "tahreemrasul",
+  "description": "LangChain agent that solves arithmetic, logic/word problems, and knowledge questions using Calculator, Reasoning, and Wikipedia tools.",
+  "repository": "https://github.com/computer-agent/math_app_langchain",
+  "path": "",
+  "version": "1.0.0",
+  "category": "education",
+  "tags": ["math", "langchain", "reasoning", "openai", "calculator", "wikipedia", "chainlit", "education", "word-problems"],
+  "license": "MIT",
+  "model": "openai:gpt-3.5-turbo-instruct",
+  "adapters": ["system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **Math Wiz** by [@tahreemrasul](https://github.com/tahreemrasul) to the registry.

**Repo:** https://github.com/tahreemrasul/math_app_langchain
**Category:** education
**Tags:** math, langchain, reasoning, openai, calculator, wikipedia, chainlit, word-problems

Math Wiz is a clean, focused LangChain REACT agent that routes arithmetic, logic/word problems, and general knowledge questions to the right tool automatically (Calculator → LLMMathChain, Reasoning Tool → LLMChain, Wikipedia). Single-file `chatbot.py`, Chainlit web UI, no heavy infra.

A GAP adoption PR (`agent.yaml` + `SOUL.md`) has been proposed upstream at https://github.com/tahreemrasul/math_app_langchain/pull/2 — the registry entry currently points at the fork branch where the files are validated and live. Once the upstream PR is merged, `repository` can be updated to point at the canonical upstream URL.

Local validation: ✓ passed `npx tsx scripts/validate.ts agents/tahreemrasul__math-wiz`

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.