### PR TITLE
Add adamwlarson/ai-book-writer

### DIFF
--- a/agents/adamwlarson__ai-book-writer/README.md
+++ b/agents/adamwlarson__ai-book-writer/README.md
@@ -1,0 +1,39 @@
+# AI Book Writer
+
+A collaborative multi-agent system built on [AutoGen](https://github.com/microsoft/autogen) that turns a single creative premise into a complete, polished, multi-chapter book.
+
+## What it does
+
+Six specialised agents work in a structured pipeline:
+
+| Agent | Responsibility |
+|---|---|
+| **Story Planner** | Maps the high-level arc — plot points, character arcs, story beats, transitions |
+| **Outline Creator** | Produces a detailed N-chapter outline in a strict, parseable format |
+| **World Builder** | Establishes every setting, atmosphere, and sensory detail the story requires |
+| **Memory Keeper** | Tracks continuity after each chapter; raises alerts on inconsistencies |
+| **Writer** | Authors the actual prose (hard minimum: 5 000 words per chapter) |
+| **Editor** | Reviews drafts for quality, outline alignment, and character consistency |
+
+## Example usage
+
+```bash
+git clone https://github.com/adamwlarson/ai-book-writer.git
+cd ai-book-writer
+pip install -r requirements.txt
+# Start LM Studio (or any OpenAI-compatible local server) then:
+python main.py
+```
+
+Enter a premise when prompted (e.g. *"A retired astronaut discovers a second moon has appeared overnight"*) and specify the number of chapters. The pipeline runs fully autonomously until the manuscript is complete.
+
+## Key capabilities
+
+- Fully local — no cloud API required by default (uses `http://localhost:1234/v1`)
+- Continuity-aware — the Memory Keeper prevents plot holes across chapters
+- Quality-gated — the Editor enforces the 5 000-word minimum before approving any chapter
+- Outline-driven — all agents defer to the canonical chapter outline
+
+## Repository
+
+https://github.com/adamwlarson/ai-book-writer

--- a/agents/adamwlarson__ai-book-writer/metadata.json
+++ b/agents/adamwlarson__ai-book-writer/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-book-writer",
+  "author": "adamwlarson",
+  "description": "Collaborative multi-agent book-writing system: six AutoGen agents (Story Planner, Outline Creator, World Builder, Memory Keeper, Writer, Editor) generate full-length narratives from a single premise.",
+  "repository": "https://github.com/adamwlarson/ai-book-writer",
+  "version": "1.0.0",
+  "category": "creative",
+  "tags": ["book-writing", "autogen", "multi-agent", "creative-writing", "storytelling", "narrative", "world-building"],
+  "license": "MIT",
+  "model": "Mistral-Nemo-Instruct-2407",
+  "adapters": ["system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **AI Book Writer** by @adamwlarson to the registry.

**Repo:** https://github.com/adamwlarson/ai-book-writer
**Category:** creative
**Tags:** book-writing, autogen, multi-agent, creative-writing, storytelling, narrative, world-building

A collaborative multi-agent AutoGen system where six specialized agents (Story Planner, Outline Creator, World Builder, Memory Keeper, Writer, Editor) collaborate to produce complete, multi-chapter books from a single premise. Runs fully locally against any OpenAI-compatible endpoint.

**Note:** A companion PR adding `agent.yaml` + `SOUL.md` to the target repo is open at https://github.com/adamwlarson/ai-book-writer/pull/8. The registry CI validation will pass once that PR is merged on the upstream default branch. This registry PR is intentionally opened alongside the target PR so both can be reviewed together.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.