### PR TITLE
Add Saik0s/DevAssistant

### DIFF
--- a/agents/Saik0s__dev-assistant/README.md
+++ b/agents/Saik0s__dev-assistant/README.md
@@ -1,0 +1,46 @@
+# DevAssistant
+
+**DevAssistant** is a personal, task-driven autonomous agent by [@Saik0s](https://github.com/Saik0s) that helps developers achieve complex objectives without hand-holding every step.
+
+## What it does
+
+Given a single high-level goal (e.g. *"scaffold a FastAPI service with JWT auth and write tests"*), DevAssistant:
+
+1. **Decomposes** the objective into prioritised milestones using GPT-4
+2. **Executes** each task with a rich tool-set — Python REPL, Bash, file I/O, web scraping, GitHub integration, DuckDuckGo search
+3. **Remembers** results in a local FAISS semantic memory so later tasks can build on earlier ones
+4. **Evaluates** whether the objective is fully achieved after every cycle
+5. **Iterates** — generates new tasks, re-prioritises, and continues until done
+
+It is particularly suited for tasks whose output is a set of files: code generation, research reports, project scaffolding, and migrations.
+
+## Key capabilities
+
+- Milestone-based task decomposition (`ReasoningModule`)
+- Multi-tool execution with guardrails (`ExecutionModule`)
+- Semantic memory retrieval (`MemoryModule` + FAISS)
+- Iterative self-evaluation and loop termination (`EvaluationModule`)
+- Runs safely inside Docker (`make docker`) — recommended for file-system-modifying tasks
+
+## Example usage
+
+```bash
+# Install dependencies
+make install
+
+# Run with an objective
+python -m main --obj "Create a Python script that fetches the top 10 Hacker News stories and saves them to stories.json"
+
+# Run inside Docker (recommended for destructive tasks)
+make docker
+```
+
+## Requirements
+
+- Python 3.11+
+- OpenAI API key (`OPENAI_API_KEY`)
+
+## Links
+
+- [Repository](https://github.com/Saik0s/DevAssistant)
+- [GitAgent Protocol](https://gitagent.sh)

--- a/agents/Saik0s__dev-assistant/metadata.json
+++ b/agents/Saik0s__dev-assistant/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "dev-assistant",
+  "author": "Saik0s",
+  "description": "Task-driven autonomous agent that decomposes developer objectives into prioritised milestones, executes them with Python/Bash/file/web tools, and iterates until done.",
+  "repository": "https://github.com/Saik0s/DevAssistant",
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "tags": ["autonomous-agent", "task-driven", "langchain", "gpt-4", "code-generation", "bash", "file-io"],
+  "license": "MIT",
+  "model": "openai:gpt-4",
+  "adapters": ["openai", "system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **dev-assistant** by [@Saik0s](https://github.com/Saik0s) to the registry.

**Repo:** https://github.com/Saik0s/DevAssistant  
**PR adding GAP files:** https://github.com/Saik0s/DevAssistant/pull/6  
**Category:** `developer-tools`  
**Tags:** `autonomous-agent`, `task-driven`, `langchain`, `gpt-4`, `code-generation`, `bash`, `file-io`

DevAssistant is a personal, task-driven autonomous agent that decomposes developer objectives into prioritised milestones, executes them with Python/Bash/file-system/web tools, and iterates until the goal is achieved. Clean portable LangChain agent, MIT licensed, 72 ⭐.

The repo has a valid `agent.yaml` + `SOUL.md` on the `gitagent-protocol` branch (PR #6 open for review). Once merged these files will be on the default branch and CI validation will pass.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.