### PR TITLE
Add omarshahine/claude-rename-agent

### DIFF
--- a/agents/omarshahine__claude-rename-agent/README.md
+++ b/agents/omarshahine__claude-rename-agent/README.md
@@ -1,0 +1,70 @@
+# claude-rename-agent
+
+An AI-powered file renaming agent built with the Claude Agent SDK that brings
+order to chaotic document folders. It reads PDFs, images, and text files,
+figures out what each document actually *is*, and renames it with a clean,
+consistent pattern — then remembers that pattern for next time.
+
+## What it does
+
+- **Analyzes documents** — extracts content from PDFs, images, and text files
+  to understand their type and key metadata (date, vendor, amount, etc.)
+- **Classifies documents** — identifies receipts, tax forms (W-2, 1099, K-1),
+  bank statements, invoices, contracts, medical records, insurance documents,
+  payslips, and more
+- **Applies pattern-based naming** — uses token templates like
+  `{Date:YYYY-MM-DD} - {Merchant} - {Amount}` applied consistently across a
+  whole batch
+- **Learns patterns** — saves a naming pattern after a successful batch run so
+  the next similar folder is handled automatically
+- **Batch-processes folders** — groups similar documents and renames the whole
+  group in one shot with a preview-before-apply workflow
+
+## Example usage
+
+```bash
+# Install
+pip install claude-rename-agent
+
+# Interactive session
+rename-agent
+
+# Process a folder
+rename-agent --files ~/Downloads/tax-forms
+
+# Dry run (preview only, no changes)
+rename-agent --files ~/Documents/Receipts --dry-run
+
+# Use a specific pattern
+rename-agent --files ~/Downloads/bank-statements \
+  --pattern "{Year}-{Date:MM} {Bank Name} Statement"
+```
+
+Or add the Claude Code skill and just ask:
+
+```
+> Rename these tax documents in ~/Downloads/tax-forms
+> Organize my receipts with date and merchant name
+```
+
+## Key capabilities
+
+| Capability | Detail |
+|-----------|--------|
+| Document types | 15+ types: receipts, bills, tax docs, bank statements, invoices, contracts, medical, insurance, investments, payslips, identity, correspondence, manuals, photos, general |
+| Pattern tokens | `{Date}`, `{Merchant}`, `{Amount}`, `{Institution}`, `{Form Type}`, `{Account Number}`, `{Description}`, `{Title}`, and more |
+| Learning | Patterns are saved per document-type and reused across sessions |
+| Safety | Always previews renames before applying; `--dry-run` flag available |
+| Integration | Works as a CLI tool and as a Claude Code skill |
+
+## Requirements
+
+- Python 3.10+
+- Claude Code (for skill mode)
+- `ANTHROPIC_API_KEY` environment variable
+
+## Links
+
+- **Repository:** https://github.com/omarshahine/claude-rename-agent
+- **License:** MIT
+- **Author:** [@omarshahine](https://github.com/omarshahine)

--- a/agents/omarshahine__claude-rename-agent/metadata.json
+++ b/agents/omarshahine__claude-rename-agent/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-rename-agent",
+  "author": "omarshahine",
+  "description": "AI-powered file renaming agent that analyzes PDFs, images and text, classifies documents, and applies consistent pattern-based naming with learned templates.",
+  "repository": "https://github.com/computer-agent/claude-rename-agent",
+  "path": "",
+  "version": "0.1.0",
+  "category": "productivity",
+  "tags": ["file-management", "document-analysis", "automation", "renaming", "pdf", "pattern-learning", "claude-sdk", "batch-processing"],
+  "license": "MIT",
+  "model": "claude-sonnet-4-5-20250929",
+  "adapters": ["claude-code", "system-prompt"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **claude-rename-agent** by [@omarshahine](https://github.com/omarshahine) to the registry.

**What it does:** An AI-powered file renaming agent built with the Claude Agent SDK that analyzes PDFs, images, and text files, classifies them by document type (receipts, tax forms, bank statements, invoices, etc.), and applies consistent token-based naming patterns like `{Date:YYYY-MM-DD} - {Merchant} - {Amount}`. It learns patterns over time and supports batch processing with a preview-before-apply safety step.

**Category:** `productivity` | **Tags:** file-management, document-analysis, automation, renaming, pdf, pattern-learning, claude-sdk, batch-processing

**Upstream repo:** https://github.com/omarshahine/claude-rename-agent (MIT)

> **Note:** A GAP adoption PR is currently open at the upstream repo ([omarshahine/claude-rename-agent#4](https://github.com/omarshahine/claude-rename-agent/pull/4)). The registry `metadata.json` temporarily points at the GAP promoter fork (which has the files) so CI validates cleanly. Once the upstream PR merges, `repository` will be updated to the canonical URL. Happy to update that in this PR or a follow-up.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers discover the standard.