### PR TITLE
Add kandada/aacode

### DIFF
--- a/agents/kandada__aacode/README.md
+++ b/agents/kandada__aacode/README.md
@@ -1,0 +1,48 @@
+# AACode
+
+A lightweight, 100%-Python CLI coding agent built on a **ReAct (Reason + Act) loop**. Give it a task in plain language — it plans, writes code, runs it, reads the errors, fixes them, and ships a working result. No manual prompt engineering needed.
+
+---
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/kandada/aacode
+```
+
+---
+
+## What It Can Do
+
+- **Autonomous coding** — Write, run, debug, and verify code end-to-end, with TDD loops that don't quit until tests pass
+- **Multi-step task planning** — Builds a live TODO list, updates it as work progresses, and verifies each item before marking it done
+- **Shell access** — Runs arbitrary shell commands, installs dependencies, writes scripts, and interprets output
+- **Web search & fetch** — Searches via SearXNG and fetches URLs for real-time information during coding tasks
+- **Sub-agent delegation** — Spawns isolated sub-agents for sub-tasks that would crowd the main context window
+- **Multimodal input** — Understands screenshots, UI mockups, and images to generate matching code
+- **Extensible skills** — pandas, numpy, Playwright, and user-defined skills auto-loaded from `skills/`
+- **MCP integration** — Connects to any MCP server via stdio or SSE
+
+## Provider-agnostic
+
+Works with **DeepSeek** (default), OpenAI GPT-4, Anthropic Claude, Kimi K2.5, Gemini, and any OpenAI-compatible API. Switch providers with three env vars — no code changes.
+
+```bash
+export LLM_API_KEY="your-key"
+export LLM_API_URL="https://api.deepseek.com/v1"
+export LLM_MODEL_NAME="deepseek-chat"
+aacode run -p ./my-project "Add unit tests for all public functions"
+```
+
+## Quick start
+
+```bash
+pip install aacode
+aacode init          # configure LLM provider
+aacode run -p /your/project "your task"
+```
+
+---
+
+## Built with
+[gitagent](https://github.com/open-gitagent/gitagent) — a git-native, framework-agnostic open standard for AI agents.

--- a/agents/kandada__aacode/metadata.json
+++ b/agents/kandada__aacode/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "aacode",
+  "author": "kandada",
+  "description": "Lightweight, 100%-Python CLI coding agent on a ReAct loop — plans, writes, runs, and tests code autonomously. Provider-agnostic: DeepSeek, OpenAI, Claude, and more.",
+  "repository": "https://github.com/kandada/aacode",
+  "version": "1.7.8",
+  "category": "developer-tools",
+  "tags": ["coding-agent", "cli", "react-architecture", "deepseek", "openai", "anthropic", "python", "agentic-coding", "multi-provider", "sub-agents"],
+  "license": "GPL-3.0",
+  "model": "deepseek-chat",
+  "adapters": ["system-prompt", "openai", "claude-code"],
+  "icon": false,
+  "banner": false
+}


### PR DESCRIPTION
Adds **aacode** by [kandada](https://github.com/kandada) to the registry.

**Repo:** https://github.com/kandada/aacode
**Target repo PR (adds agent.yaml + SOUL.md):** https://github.com/kandada/aacode/pull/3
**Category:** developer-tools
**License:** GPL-3.0

AACode is a lightweight, 100%-Python CLI coding agent on a ReAct loop. It plans tasks, writes code, executes shell commands, runs tests, and iterates until everything passes — provider-agnostic across DeepSeek, OpenAI, Claude, and more. Pip-installable as `aacode`.

---

If GAP looks useful, the project lives at ⭐ **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.