### PR TITLE
Add PigeonDan1/paper_claw

### DIFF
--- a/agents/PigeonDan1__paper-claw/README.md
+++ b/agents/PigeonDan1__paper-claw/README.md
@@ -1,0 +1,64 @@
+# Paper Claw
+
+An intelligent research digest agent that monitors arXiv daily, classifies papers by topic, generates concise multilingual summaries using your preferred LLM provider, and delivers personalised HTML and Markdown email digests.
+
+---
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/PigeonDan1/paper_claw
+```
+
+---
+
+## What It Can Do
+
+- **Multi-Source Fetching** — arXiv (170+ categories); extensible to other academic sources
+- **Topic Classification** — Keyword-based classification into user-defined research categories (e.g. ASR, TTS, LLM, RAG, Object Detection, Diffusion Models)
+- **Multilingual AI Summaries** — Generates 2–4 sentence summaries in Chinese, English, Japanese, Korean, German, French, or Spanish — faithful to the abstract, never invented
+- **Multi-Provider LLM** — DeepSeek → Kimi → OpenAI → Anthropic Claude → Gemini → rule-based fallback; resilient even without API keys
+- **Email Delivery** — HTML preview (first 3 papers) + full Markdown digest as attachment, sent to configurable recipient list
+- **Research Presets** — One-command setup for Speech & Audio, NLP & LLM, Computer Vision, or General AI/ML research
+- **State Tracking** — Auto-deduplication across runs; never emails a paper twice
+- **GitHub Actions Ready** — Includes daily workflow for zero-ops scheduled digests
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/PigeonDan1/paper_claw.git
+cd paper_claw
+pip install -r requirements.txt
+cp .env.example .env        # add SMTP + LLM API keys
+cp config/recipients.example.json config/recipients.json
+python scripts/main.py --day 2026-03-10
+```
+
+Or, for AI agents, apply a preset in one line:
+
+```python
+from skill.example import apply_preset
+apply_preset("nlp")  # configures arXiv categories + classification automatically
+```
+
+---
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SMTP_HOST` | ✅ | SMTP server host |
+| `SMTP_PORT` | ✅ | SMTP port (usually 465) |
+| `SMTP_USER` | ✅ | Sender email address |
+| `SMTP_PASS` | ✅ | SMTP auth token or app password |
+| `DEEPSEEK_API_KEY` | ☑️ | Preferred provider for summaries |
+| `MOONSHOT_API_KEY` | ☑️ | Kimi (recommended for Chinese) |
+| `OPENAI_API_KEY` | ☑️ | OpenAI fallback |
+| `ANTHROPIC_API_KEY` | ☑️ | Claude fallback |
+| `GOOGLE_API_KEY` | ☑️ | Gemini fallback |
+
+At least one LLM API key is recommended; rule-based summaries work without any.
+
+> **Note:** `agent.yaml` and `SOUL.md` are being added to the repo via [PR #2](https://github.com/PigeonDan1/paper_claw/pull/2). This registry entry will pass CI validation once that PR is merged.

--- a/agents/PigeonDan1__paper-claw/metadata.json
+++ b/agents/PigeonDan1__paper-claw/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "paper-claw",
+  "author": "PigeonDan1",
+  "description": "AI research digest agent: fetches arXiv papers, classifies by topic, generates multilingual summaries via DeepSeek/OpenAI/Claude, and emails daily digests.",
+  "repository": "https://github.com/PigeonDan1/paper_claw",
+  "version": "2.0.0",
+  "category": "research",
+  "tags": ["arxiv", "research", "papers", "digest", "nlp", "ai-agent", "email", "multilingual"],
+  "license": "MIT",
+  "model": "deepseek:deepseek-chat",
+  "adapters": ["system-prompt", "claude-code"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **Paper Claw** by [PigeonDan1](https://github.com/PigeonDan1) to the Open GAP registry.

Repo: https://github.com/PigeonDan1/paper_claw — MIT licence, 31 ⭐, actively maintained.

**What Paper Claw does:** An AI research digest agent that fetches papers from arXiv (170+ categories), classifies them by research topic, generates multilingual summaries (7 languages) via DeepSeek / Kimi / OpenAI / Claude / Gemini with automatic fallback, and emails personalised daily digests to researchers. Portable — runs with just SMTP + an LLM API key.

- Category: `research`
- Tags: `arxiv`, `research`, `papers`, `digest`, `nlp`, `ai-agent`, `email`, `multilingual`
- Model: `deepseek:deepseek-chat` (with 4 fallback providers)
- Adapters: `system-prompt`, `claude-code`

**CI note:** `agent.yaml` + `SOUL.md` are proposed to the target repo via [PR #2](https://github.com/PigeonDan1/paper_claw/pull/2). The CI validation for those files will pass once that PR is merged. All other checks (metadata schema, folder name, README) are satisfied.

---

⭐ If GAP looks useful, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.