### PR TITLE
Add Yunle-Lee/kilee-agent

### DIFF
--- a/agents/Yunle-Lee__kilee-agent/README.md
+++ b/agents/Yunle-Lee__kilee-agent/README.md
@@ -1,0 +1,44 @@
+# KiLee Agent
+
+**KiLee** is a DeepSeek-powered terminal AI agent that lets you read and write
+files, run shell commands, search the web, and keep a persistent memory — all
+from your command line.
+
+## What it does
+
+- 📁 **File operations** — read, write, edit, list directories, grep content
+- 💻 **Shell execution** — run any bash command with risk-based approval
+- 🌐 **Web** — search and fetch page content for up-to-date answers
+- 🧠 **Memory** — save facts and preferences across sessions (`~/.kilee/memory.json`)
+- 🗜️ **Context compression** — auto-compresses long conversations to preserve tokens
+- 🔌 **Multi-provider** — DeepSeek (default), OpenAI, Groq, OpenRouter, or any
+  OpenAI-compatible endpoint
+
+## Installation
+
+```bash
+git clone https://github.com/Yunle-Lee/KiLee-agent.git
+cd KiLee-agent
+pip install -e .
+kilee         # launches setup wizard on first run
+```
+
+## Usage
+
+```bash
+kilee                        # interactive chat
+kilee setup                  # configure API key and model
+kilee whoami                 # show current config
+```
+
+Ask KiLee anything. It will use its tools to act, not just describe.
+
+## Context Engineering
+
+Drop a `KILEE.md` file in your project root — KiLee automatically injects it
+into every session, giving it immediate awareness of your codebase, stack, and
+conventions.
+
+## License
+
+MIT — [GitHub](https://github.com/Yunle-Lee/KiLee-agent)

--- a/agents/Yunle-Lee__kilee-agent/metadata.json
+++ b/agents/Yunle-Lee__kilee-agent/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "kilee-agent",
+  "author": "Yunle-Lee",
+  "description": "DeepSeek-powered terminal AI agent — reads files, runs shell commands, writes code, searches the web, and remembers facts across sessions.",
+  "repository": "https://github.com/Yunle-Lee/KiLee-agent",
+  "version": "0.3.0",
+  "category": "developer-tools",
+  "tags": ["terminal", "cli", "deepseek", "openai-compatible", "agentic", "file-management", "web-search", "persistent-memory"],
+  "license": "MIT",
+  "model": "deepseek-chat",
+  "adapters": ["system-prompt", "openai"],
+  "icon": false
+}


### PR DESCRIPTION
Adds **kilee-agent** by [Yunle-Lee](https://github.com/Yunle-Lee) to the Open GAP registry.

**Repo:** https://github.com/Yunle-Lee/KiLee-agent

**What KiLee does:** A DeepSeek-powered terminal AI agent — reads files, runs shell commands, writes code, searches the web, and remembers facts across sessions. Portable (pip-installable), MIT licensed, supports any OpenAI-compatible API.

**Category:** developer-tools  
**Tags:** terminal, cli, deepseek, openai-compatible, agentic, file-management, web-search, persistent-memory

**GAP adoption PR** (proposes `agent.yaml` + `SOUL.md` to the upstream repo): https://github.com/Yunle-Lee/KiLee-agent/pull/1

---

⭐ If GAP looks useful to you, the project lives at **https://github.com/open-gitagent/opengap** — a star helps more maintainers find the standard.